### PR TITLE
eddsa-common-optimization

### DIFF
--- a/circuit/src/eddsa/eddsa_gadgets.rs
+++ b/circuit/src/eddsa/eddsa_gadgets.rs
@@ -1,0 +1,646 @@
+use super::native::ops::{add_exp, add_value, double_exp, double_value};
+use crate::gadgets::bits2num::{Bits2NumChip, Bits2NumConfig};
+use halo2wrong::{
+	curves::bn256::Fr,
+	halo2::{
+		circuit::{AssignedCell, Layouter, Region},
+		plonk::{Advice, Column, ConstraintSystem, Error, Expression, Selector},
+		poly::Rotation,
+	},
+};
+
+#[derive(Clone)]
+/// Configuration elements for the circuit are defined here.
+pub struct EddsaGadgetsConfig {
+	/// Constructs bits2num circuit elements.
+	bits2num: Bits2NumConfig,
+	/// Configures columns for the eddsa advice.
+	eddsa_advice: [Column<Advice>; 7],
+	/// Configures fixed boolean values for each row of the circuit.
+	selectors: [Selector; 3],
+}
+
+/// Structure for the chip.
+pub struct EddsaGadgetsChip;
+
+impl EddsaGadgetsChip {
+	/// Configuration for the common eddsa circuits.
+	pub fn configure(meta: &mut ConstraintSystem<Fr>) -> EddsaGadgetsConfig {
+		let bits2num = Bits2NumChip::<_, 256>::configure(meta);
+		let eddsa_advice = [
+			meta.advice_column(),
+			meta.advice_column(),
+			meta.advice_column(),
+			meta.advice_column(),
+			meta.advice_column(),
+			meta.advice_column(),
+			meta.advice_column(),
+		];
+		let selectors = [meta.selector(), meta.selector(), meta.selector()];
+
+		eddsa_advice.map(|c| meta.enable_equality(c));
+
+		meta.create_gate("point_add", |v_cells| {
+			let s_exp = v_cells.query_selector(selectors[0]);
+
+			let r_x_exp = v_cells.query_advice(eddsa_advice[0], Rotation::cur());
+			let r_y_exp = v_cells.query_advice(eddsa_advice[1], Rotation::cur());
+			let r_z_exp = v_cells.query_advice(eddsa_advice[2], Rotation::cur());
+
+			let e_x_exp = v_cells.query_advice(eddsa_advice[3], Rotation::cur());
+			let e_y_exp = v_cells.query_advice(eddsa_advice[4], Rotation::cur());
+			let e_z_exp = v_cells.query_advice(eddsa_advice[5], Rotation::cur());
+
+			let r_x_next_exp = v_cells.query_advice(eddsa_advice[0], Rotation::next());
+			let r_y_next_exp = v_cells.query_advice(eddsa_advice[1], Rotation::next());
+			let r_z_next_exp = v_cells.query_advice(eddsa_advice[2], Rotation::next());
+
+			let (r_x3, r_y3, r_z3) = add_exp(
+				r_x_exp.clone(),
+				r_y_exp.clone(),
+				r_z_exp.clone(),
+				e_x_exp.clone(),
+				e_y_exp.clone(),
+				e_z_exp.clone(),
+			);
+
+			vec![
+				// Ensure the point addition of `r` and `e` is properly calculated.
+				s_exp.clone() * (r_x_next_exp - r_x3),
+				s_exp.clone() * (r_y_next_exp - r_y3),
+				s_exp.clone() * (r_z_next_exp - r_z3),
+			]
+		});
+
+		meta.create_gate("into_affine", |v_cells| {
+			let s_exp = v_cells.query_selector(selectors[1]);
+
+			let one = Expression::Constant(Fr::one());
+			let r_x_exp = v_cells.query_advice(eddsa_advice[0], Rotation::cur());
+			let r_y_exp = v_cells.query_advice(eddsa_advice[1], Rotation::cur());
+			let r_z_exp = v_cells.query_advice(eddsa_advice[2], Rotation::cur());
+
+			let r_x_affine_exp = v_cells.query_advice(eddsa_advice[3], Rotation::cur());
+			let r_y_affine_exp = v_cells.query_advice(eddsa_advice[4], Rotation::cur());
+			let r_z_invert_exp = v_cells.query_advice(eddsa_advice[5], Rotation::cur());
+
+			let affine_x = r_x_exp * r_z_invert_exp.clone();
+			let affine_y = r_y_exp * r_z_invert_exp.clone();
+
+			vec![
+				// Ensure the affine representation is properly calculated.
+				s_exp.clone() * (r_x_affine_exp - affine_x),
+				s_exp.clone() * (r_y_affine_exp - affine_y),
+				s_exp * (r_z_exp * r_z_invert_exp - one),
+			]
+		});
+
+		meta.create_gate("scalar_mul", |v_cells| {
+			let s_exp = v_cells.query_selector(selectors[2]);
+			let bit_exp = v_cells.query_advice(eddsa_advice[0], Rotation::cur());
+
+			let r_x_exp = v_cells.query_advice(eddsa_advice[1], Rotation::cur());
+			let r_y_exp = v_cells.query_advice(eddsa_advice[2], Rotation::cur());
+			let r_z_exp = v_cells.query_advice(eddsa_advice[3], Rotation::cur());
+
+			let e_x_exp = v_cells.query_advice(eddsa_advice[4], Rotation::cur());
+			let e_y_exp = v_cells.query_advice(eddsa_advice[5], Rotation::cur());
+			let e_z_exp = v_cells.query_advice(eddsa_advice[6], Rotation::cur());
+
+			let r_x_next_exp = v_cells.query_advice(eddsa_advice[1], Rotation::next());
+			let r_y_next_exp = v_cells.query_advice(eddsa_advice[2], Rotation::next());
+			let r_z_next_exp = v_cells.query_advice(eddsa_advice[3], Rotation::next());
+
+			let e_x_next_exp = v_cells.query_advice(eddsa_advice[4], Rotation::next());
+			let e_y_next_exp = v_cells.query_advice(eddsa_advice[5], Rotation::next());
+			let e_z_next_exp = v_cells.query_advice(eddsa_advice[6], Rotation::next());
+
+			let (r_x3, r_y3, r_z3) = add_exp(
+				r_x_exp.clone(),
+				r_y_exp.clone(),
+				r_z_exp.clone(),
+				e_x_exp.clone(),
+				e_y_exp.clone(),
+				e_z_exp.clone(),
+			);
+
+			let (e_x3, e_y3, e_z3) = double_exp(e_x_exp, e_y_exp, e_z_exp);
+
+			// Select the next value based on a `bit` -- see `select` gadget.
+			let selected_r_x =
+				bit_exp.clone() * (r_x3 - r_x_exp.clone()) - (r_x_next_exp - r_x_exp);
+			let selected_r_y =
+				bit_exp.clone() * (r_y3 - r_y_exp.clone()) - (r_y_next_exp - r_y_exp);
+			let selected_r_z =
+				bit_exp.clone() * (r_z3 - r_z_exp.clone()) - (r_z_next_exp - r_z_exp);
+
+			vec![
+				// Ensure the point addition of `r` and `e` is properly calculated.
+				s_exp.clone() * selected_r_x,
+				s_exp.clone() * selected_r_y,
+				s_exp.clone() * selected_r_z,
+				// Ensure the `e` doubling is properly calculated.
+				s_exp.clone() * (e_x_next_exp - e_x3),
+				s_exp.clone() * (e_y_next_exp - e_y3),
+				s_exp * (e_z_next_exp - e_z3),
+			]
+		});
+
+		EddsaGadgetsConfig { bits2num, eddsa_advice, selectors }
+	}
+
+	/// Synthesize the add_point circuit.
+	pub fn add_point(
+		// Assigns a cell for the r_x.
+		r_x: AssignedCell<Fr, Fr>,
+		// Assigns a cell for the r_y.
+		r_y: AssignedCell<Fr, Fr>,
+		// Assigns a cell for the r_z.
+		r_z: AssignedCell<Fr, Fr>,
+		// Assigns a cell for the e_x.
+		e_x: AssignedCell<Fr, Fr>,
+		// Assigns a cell for the e_y.
+		e_y: AssignedCell<Fr, Fr>,
+		// Assigns a cell for the e_z.
+		e_z: AssignedCell<Fr, Fr>,
+		config: EddsaGadgetsConfig,
+		mut layouter: impl Layouter<Fr>,
+	) -> Result<
+		(
+			AssignedCell<Fr, Fr>,
+			AssignedCell<Fr, Fr>,
+			AssignedCell<Fr, Fr>,
+		),
+		Error,
+	> {
+		layouter.assign_region(
+			|| "add",
+			|mut region: Region<'_, Fr>| {
+				config.selectors[0].enable(&mut region, 0)?;
+
+				let r_x = r_x.copy_advice(|| "r_x", &mut region, config.eddsa_advice[0], 0)?;
+				let r_y = r_y.copy_advice(|| "r_y", &mut region, config.eddsa_advice[1], 0)?;
+				let r_z = r_z.copy_advice(|| "r_z", &mut region, config.eddsa_advice[2], 0)?;
+				let e_x = e_x.copy_advice(|| "e_x", &mut region, config.eddsa_advice[3], 0)?;
+				let e_y = e_y.copy_advice(|| "e_y", &mut region, config.eddsa_advice[4], 0)?;
+				let e_z = e_z.copy_advice(|| "e_z", &mut region, config.eddsa_advice[5], 0)?;
+
+				// Add `r` and `e`.
+				let (r_x3, r_y3, r_z3) = add_value(
+					r_x.value_field(),
+					r_y.value_field(),
+					r_z.value_field(),
+					e_x.value_field(),
+					e_y.value_field(),
+					e_z.value_field(),
+				);
+
+				let r_x_res = region.assign_advice(
+					|| "r_x",
+					config.eddsa_advice[0],
+					1,
+					|| r_x3.evaluate(),
+				)?;
+				let r_y_res = region.assign_advice(
+					|| "r_y",
+					config.eddsa_advice[1],
+					1,
+					|| r_y3.evaluate(),
+				)?;
+				let r_z_res = region.assign_advice(
+					|| "r_z",
+					config.eddsa_advice[2],
+					1,
+					|| r_z3.evaluate(),
+				)?;
+
+				Ok((r_x_res, r_y_res, r_z_res))
+			},
+		)
+	}
+
+	/// Synthesize the into_affine circuit.
+	pub fn into_affine(
+		// Assigns a cell for the r_x.
+		r_x: AssignedCell<Fr, Fr>,
+		// Assigns a cell for the r_y.
+		r_y: AssignedCell<Fr, Fr>,
+		// Assigns a cell for the r_z.
+		r_z: AssignedCell<Fr, Fr>,
+		config: EddsaGadgetsConfig,
+		mut layouter: impl Layouter<Fr>,
+	) -> Result<(AssignedCell<Fr, Fr>, AssignedCell<Fr, Fr>), Error> {
+		layouter.assign_region(
+			|| "into_affine",
+			|mut region: Region<'_, Fr>| {
+				config.selectors[1].enable(&mut region, 0)?;
+
+				r_x.copy_advice(|| "r_x", &mut region, config.eddsa_advice[0], 0)?;
+				r_y.copy_advice(|| "r_y", &mut region, config.eddsa_advice[1], 0)?;
+				r_z.copy_advice(|| "r_z", &mut region, config.eddsa_advice[2], 0)?;
+
+				// Calculating affine representation for the point.
+				// Divide both points with the third dimension to get the affine point.
+				// Shrinking a line to a dot is why some projective
+				// space coordinates returns to the same affine points.
+				let z_invert = r_z.value_field().invert();
+				let r_x_affine = r_x.value_field() * z_invert;
+				let r_y_affine = r_y.value_field() * z_invert;
+
+				let x = region.assign_advice(
+					|| "r_x_affine",
+					config.eddsa_advice[3],
+					0,
+					|| r_x_affine.evaluate(),
+				)?;
+				let y = region.assign_advice(
+					|| "r_y_affine",
+					config.eddsa_advice[4],
+					0,
+					|| r_y_affine.evaluate(),
+				)?;
+				region.assign_advice(
+					|| "r_z_invert",
+					config.eddsa_advice[5],
+					0,
+					|| z_invert.evaluate(),
+				)?;
+
+				Ok((x, y))
+			},
+		)
+	}
+
+	/// Synthesize the scalar_mul circuit.
+	pub fn scalar_mul<const B: usize>(
+		// Assigns a cell for the e_x.
+		e_x: AssignedCell<Fr, Fr>,
+		// Assigns a cell for the e_y.
+		e_y: AssignedCell<Fr, Fr>,
+		// Assigns a cell for the e_z.
+		e_z: AssignedCell<Fr, Fr>,
+		// Assigns a cell for the value.
+		value: AssignedCell<Fr, Fr>,
+		// Constructs an array for the value bits.
+		value_bits: [Fr; B],
+		config: EddsaGadgetsConfig,
+		mut layouter: impl Layouter<Fr>,
+	) -> Result<
+		(
+			AssignedCell<Fr, Fr>,
+			AssignedCell<Fr, Fr>,
+			AssignedCell<Fr, Fr>,
+		),
+		Error,
+	> {
+		let bits2num = Bits2NumChip::new(value.clone(), value_bits);
+		let bits = bits2num.synthesize(config.bits2num, layouter.namespace(|| "bits2num"))?;
+
+		layouter.assign_region(
+			|| "scalar_mul",
+			|mut region: Region<'_, Fr>| {
+				for i in 0..bits.len() {
+					bits[i].copy_advice(|| "bit", &mut region, config.eddsa_advice[0], i)?;
+				}
+
+				let mut r_x = region.assign_advice_from_constant(
+					|| "r_x_0",
+					config.eddsa_advice[1],
+					0,
+					Fr::zero(),
+				)?;
+				let mut r_y = region.assign_advice_from_constant(
+					|| "r_y_0",
+					config.eddsa_advice[2],
+					0,
+					Fr::one(),
+				)?;
+				let mut r_z = region.assign_advice_from_constant(
+					|| "r_z_0",
+					config.eddsa_advice[3],
+					0,
+					Fr::one(),
+				)?;
+
+				let mut e_x = e_x.copy_advice(|| "e_x", &mut region, config.eddsa_advice[4], 0)?;
+				let mut e_y = e_y.copy_advice(|| "e_y", &mut region, config.eddsa_advice[5], 0)?;
+				let mut e_z = e_z.copy_advice(|| "e_z", &mut region, config.eddsa_advice[6], 0)?;
+
+				// Double and add operation.
+				for i in 0..value_bits.len() {
+					config.selectors[2].enable(&mut region, i)?;
+
+					// Add `r` and `e`.
+					let (r_x3, r_y3, r_z3) = add_value(
+						r_x.value_field(),
+						r_y.value_field(),
+						r_z.value_field(),
+						e_x.value_field(),
+						e_y.value_field(),
+						e_z.value_field(),
+					);
+
+					// Double `e`.
+					let (e_x3, e_y3, e_z3) =
+						double_value(e_x.value_field(), e_y.value_field(), e_z.value_field());
+
+					let (r_x_next, r_y_next, r_z_next) = if value_bits[i] == Fr::one() {
+						(r_x3, r_y3, r_z3)
+					} else {
+						(r_x.value_field(), r_y.value_field(), r_z.value_field())
+					};
+
+					r_x = region.assign_advice(
+						|| "r_x",
+						config.eddsa_advice[1],
+						i + 1,
+						|| r_x_next.evaluate(),
+					)?;
+					r_y = region.assign_advice(
+						|| "r_y",
+						config.eddsa_advice[2],
+						i + 1,
+						|| r_y_next.evaluate(),
+					)?;
+					r_z = region.assign_advice(
+						|| "r_z",
+						config.eddsa_advice[3],
+						i + 1,
+						|| r_z_next.evaluate(),
+					)?;
+
+					e_x = region.assign_advice(
+						|| "e_x",
+						config.eddsa_advice[4],
+						i + 1,
+						|| e_x3.evaluate(),
+					)?;
+					e_y = region.assign_advice(
+						|| "e_y",
+						config.eddsa_advice[5],
+						i + 1,
+						|| e_y3.evaluate(),
+					)?;
+					e_z = region.assign_advice(
+						|| "e_z",
+						config.eddsa_advice[6],
+						i + 1,
+						|| e_z3.evaluate(),
+					)?;
+				}
+
+				Ok((r_x, r_y, r_z))
+			},
+		)
+	}
+}
+
+#[cfg(test)]
+mod test {
+	use super::*;
+	use crate::{
+		eddsa::native::{
+			ed_on_bn254::{B8, G},
+			ops::add,
+		},
+		gadgets::bits2num::to_bits,
+		utils::{generate_params, prove_and_verify},
+	};
+	use halo2wrong::{
+		curves::bn256::{Bn256, Fr},
+		halo2::{
+			circuit::{SimpleFloorPlanner, Value},
+			dev::MockProver,
+			plonk::{Circuit, Instance},
+		},
+	};
+
+	#[derive(Clone)]
+	enum Gadgets {
+		AddPoint,
+		IntoAffine,
+		ScalarMul,
+	}
+
+	#[derive(Clone)]
+	struct TestConfig {
+		eddsa_gadgets: EddsaGadgetsConfig,
+		pub_ins: Column<Instance>,
+		temp: Column<Advice>,
+	}
+
+	#[derive(Clone)]
+	struct TestCircuit<const N: usize> {
+		inputs: [Fr; N],
+		gadget: Gadgets,
+	}
+
+	impl<const N: usize> TestCircuit<N> {
+		fn new(inputs: [Fr; N], gadget: Gadgets) -> Self {
+			Self { inputs, gadget }
+		}
+	}
+
+	impl<const N: usize> Circuit<Fr> for TestCircuit<N> {
+		type Config = TestConfig;
+		type FloorPlanner = SimpleFloorPlanner;
+
+		fn without_witnesses(&self) -> Self {
+			self.clone()
+		}
+
+		fn configure(meta: &mut ConstraintSystem<Fr>) -> TestConfig {
+			let eddsa_gadgets = EddsaGadgetsChip::configure(meta);
+			let pub_ins = meta.instance_column();
+			let temp = meta.advice_column();
+
+			meta.enable_equality(pub_ins);
+			meta.enable_equality(temp);
+
+			TestConfig { eddsa_gadgets, pub_ins, temp }
+		}
+
+		fn synthesize(
+			&self, config: TestConfig, mut layouter: impl Layouter<Fr>,
+		) -> Result<(), Error> {
+			let mut items = Vec::new();
+			for i in 0..N {
+				items.push(layouter.assign_region(
+					|| "temp",
+					|mut region: Region<'_, Fr>| {
+						let x = region.assign_advice(
+							|| "temp_inputs",
+							config.temp,
+							i,
+							|| Value::known(self.inputs[i]),
+						)?;
+						Ok(x)
+					},
+				)?);
+			}
+			match self.gadget {
+				Gadgets::AddPoint => {
+					let (x, y, z) = EddsaGadgetsChip::add_point(
+						items[0].clone(),
+						items[1].clone(),
+						items[2].clone(),
+						items[3].clone(),
+						items[4].clone(),
+						items[5].clone(),
+						config.eddsa_gadgets,
+						layouter.namespace(|| "add"),
+					)?;
+					layouter.constrain_instance(x.cell(), config.pub_ins, 0)?;
+					layouter.constrain_instance(y.cell(), config.pub_ins, 1)?;
+					layouter.constrain_instance(z.cell(), config.pub_ins, 2)?;
+				},
+				Gadgets::IntoAffine => {
+					let (x, y) = EddsaGadgetsChip::into_affine(
+						items[0].clone(),
+						items[1].clone(),
+						items[2].clone(),
+						config.eddsa_gadgets,
+						layouter.namespace(|| "into_affine"),
+					)?;
+					layouter.constrain_instance(x.cell(), config.pub_ins, 0)?;
+					layouter.constrain_instance(y.cell(), config.pub_ins, 1)?;
+				},
+				Gadgets::ScalarMul => {
+					let value_bits = to_bits::<256>(self.inputs[3].to_bytes()).map(Fr::from);
+					let (x, y, z) = EddsaGadgetsChip::scalar_mul(
+						items[0].clone(),
+						items[1].clone(),
+						items[2].clone(),
+						items[3].clone(),
+						value_bits,
+						config.eddsa_gadgets,
+						layouter.namespace(|| "scalar_mul"),
+					)?;
+					layouter.constrain_instance(x.cell(), config.pub_ins, 0)?;
+					layouter.constrain_instance(y.cell(), config.pub_ins, 1)?;
+					layouter.constrain_instance(z.cell(), config.pub_ins, 2)?;
+				},
+			}
+			Ok(())
+		}
+	}
+
+	// TEST CASES FOR THE ADD_POINT CIRCUIT
+	#[test]
+	fn should_add_point() {
+		// Testing a valid case.
+		let r = B8.projective();
+		let e = G.projective();
+		let (x_res, y_res, z_res) = add(r.x, r.y, r.z, e.x, e.y, e.z);
+		let circuit = TestCircuit::new([r.x, r.y, r.z, e.x, e.y, e.z], Gadgets::AddPoint);
+
+		let k = 7;
+		let pub_ins = vec![x_res, y_res, z_res];
+		let prover = MockProver::run(k, &circuit, vec![pub_ins]).unwrap();
+		assert_eq!(prover.verify(), Ok(()));
+	}
+
+	#[test]
+	fn should_add_point_production() {
+		let r = B8.projective();
+		let e = G.projective();
+		let (x_res, y_res, z_res) = add(r.x, r.y, r.z, e.x, e.y, e.z);
+		let circuit = TestCircuit::new([r.x, r.y, r.z, e.x, e.y, e.z], Gadgets::AddPoint);
+
+		let k = 9;
+		let rng = &mut rand::thread_rng();
+		let params = generate_params(k);
+		let pub_ins = [x_res, y_res, z_res];
+		let res = prove_and_verify::<Bn256, _, _>(params, circuit, &[&pub_ins], rng).unwrap();
+
+		assert!(res);
+	}
+
+	// TEST CASES FOR THE INTO_AFFINE CIRCUIT
+	#[test]
+	fn should_into_affine_point() {
+		// Testing a valid case.
+		let r = B8.projective();
+		let r_affine = r.affine();
+		let circuit = TestCircuit::new([r.x, r.y, r.z], Gadgets::IntoAffine);
+
+		let k = 7;
+		let pub_ins = vec![r_affine.x, r_affine.y];
+		let prover = MockProver::run(k, &circuit, vec![pub_ins]).unwrap();
+		assert_eq!(prover.verify(), Ok(()));
+	}
+
+	#[test]
+	fn should_into_affine_point_production() {
+		let r = B8.projective();
+		let r_affine = r.affine();
+		let circuit = TestCircuit::new([r.x, r.y, r.z], Gadgets::IntoAffine);
+
+		let k = 9;
+		let rng = &mut rand::thread_rng();
+		let params = generate_params(k);
+		let pub_ins = vec![r_affine.x, r_affine.y];
+		let res = prove_and_verify::<Bn256, _, _>(params, circuit, &[&pub_ins], rng).unwrap();
+
+		assert!(res);
+	}
+
+	//TEST CASES FOR THE SCALAR_MUL CIRCUIT
+	#[test]
+	fn should_mul_point_with_scalar() {
+		// Testing scalar as value 8.
+		let scalar = Fr::from(8);
+		let r = B8.projective();
+		let res = B8.mul_scalar(&scalar.to_bytes());
+		let circuit = TestCircuit::new([r.x, r.y, r.z, scalar], Gadgets::ScalarMul);
+
+		let k = 9;
+		let pub_ins = vec![res.x, res.y, res.z];
+		let prover = MockProver::run(k, &circuit, vec![pub_ins]).unwrap();
+		assert_eq!(prover.verify(), Ok(()));
+	}
+
+	#[test]
+	fn test_scalar_mul_zero() {
+		// Testing scalar as value 0.
+		let scalar = Fr::from(0);
+		let r = B8.projective();
+		let res = B8.mul_scalar(&scalar.to_bytes());
+		let circuit = TestCircuit::new([r.x, r.y, r.z, scalar], Gadgets::ScalarMul);
+
+		let k = 9;
+		let pub_ins = vec![res.x, res.y, res.z];
+		let prover = MockProver::run(k, &circuit, vec![pub_ins]).unwrap();
+		assert_eq!(prover.verify(), Ok(()));
+	}
+
+	#[test]
+	fn test_scalar_mul_one() {
+		// Testing scalar as value 1.
+		let scalar = Fr::from(1);
+		let r = B8.projective();
+		let res = B8.mul_scalar(&scalar.to_bytes());
+		let circuit = TestCircuit::new([r.x, r.y, r.z, scalar], Gadgets::ScalarMul);
+
+		let k = 9;
+		let pub_ins = vec![res.x, res.y, res.z];
+		let prover = MockProver::run(k, &circuit, vec![pub_ins]).unwrap();
+		assert_eq!(prover.verify(), Ok(()));
+	}
+
+	#[test]
+	fn should_mul_point_with_scalar_production() {
+		let scalar = Fr::from(8);
+		let r = B8.projective();
+		let res = B8.mul_scalar(&scalar.to_bytes());
+		let circuit = TestCircuit::new([r.x, r.y, r.z, scalar], Gadgets::ScalarMul);
+
+		let k = 9;
+		let rng = &mut rand::thread_rng();
+		let params = generate_params(k);
+		let pub_ins = [res.x, res.y, res.z];
+		let res = prove_and_verify::<Bn256, _, _>(params, circuit, &[&pub_ins], rng).unwrap();
+
+		assert!(res);
+	}
+}

--- a/circuit/src/eddsa/eddsa_gadgets.rs
+++ b/circuit/src/eddsa/eddsa_gadgets.rs
@@ -20,11 +20,11 @@ pub struct EddsaGadgetsConfig {
 	selectors: [Selector; 3],
 }
 
-/// Structure for the chip.
+/// Structure for the eddsa gadgets chip.
 pub struct EddsaGadgetsChip;
 
 impl EddsaGadgetsChip {
-	/// Configuration for the common eddsa circuits.
+	/// Make the circuit configs.
 	pub fn configure(meta: &mut ConstraintSystem<Fr>) -> EddsaGadgetsConfig {
 		let bits2num = Bits2NumChip::<_, 256>::configure(meta);
 		let eddsa_advice = [

--- a/circuit/src/eddsa/mod.rs
+++ b/circuit/src/eddsa/mod.rs
@@ -1,21 +1,9 @@
-/// Gadget for adding two points on an elliptic curve
-pub mod add;
-/// Gadget for converting a point into affine representation
-pub mod into_affine;
 /// Native implementation of EDDSA signature scheme
 pub mod native;
-/// Gadget for multiplying an elliptic curve point with a scalar
-pub mod scalar_mul;
 
-use self::{
-	add::{PointAddChip, PointAddConfig},
-	into_affine::{IntoAffineChip, IntoAffineConfig},
-	scalar_mul::{ScalarMulChip, ScalarMulConfig},
-};
 use crate::{
 	gadgets::{
-		and::{AndChip, AndConfig},
-		is_equal::{IsEqualChip, IsEqualConfig},
+		common::{CommonChip, CommonConfig, CommonEddsaConfig},
 		lt_eq::{LessEqualChip, LessEqualConfig},
 	},
 	params::poseidon_bn254_5x5::Params,
@@ -34,21 +22,14 @@ use native::ed_on_bn254::{B8, SUBORDER};
 #[derive(Clone)]
 /// Configuration elements for the circuit are defined here.
 struct EddsaConfig {
-	/// Constructs scalar mul circuit elements.
-	scalar_mul_s: ScalarMulConfig,
-	scalar_mul_mh: ScalarMulConfig,
+	/// Constructs common eddsa circuit elements.
+	common_eddsa: CommonEddsaConfig,
+	/// Constructs common circuit elements.
+	common: CommonConfig,
 	/// Constructs lt_eq circuit elements.
 	lt_eq: LessEqualConfig,
-	/// Constructs point add circuit elements.
-	point_add: PointAddConfig,
-	/// Constructs into_affine circuit elements.
-	into_affine: IntoAffineConfig,
 	/// Constructs poseidon circuit elements.
 	poseidon: PoseidonConfig<5>,
-	/// Constructs is_eq circuit elements.
-	is_eq: IsEqualConfig,
-	/// Constructs and circuit elements.
-	and: AndConfig,
 	/// Configures a column for the temp.
 	temp: Column<Advice>,
 }
@@ -101,29 +82,15 @@ impl EddsaChip {
 
 	/// Make the circuit config.
 	pub fn configure(meta: &mut ConstraintSystem<Fr>) -> EddsaConfig {
-		let scalar_mul_s = ScalarMulChip::<252>::configure(meta);
-		let scalar_mul_mh = ScalarMulChip::<256>::configure(meta);
+		let common = CommonChip::configure_gadgets(meta);
+		let common_eddsa = CommonChip::<Fr>::configure_eddsa(meta);
 		let lt_eq = LessEqualChip::configure(meta);
-		let point_add = PointAddChip::configure(meta);
-		let into_affine = IntoAffineChip::configure(meta);
 		let poseidon = PoseidonChip::<_, 5, Params>::configure(meta);
-		let is_eq = IsEqualChip::configure(meta);
-		let and = AndChip::configure(meta);
 		let temp = meta.advice_column();
 
 		meta.enable_equality(temp);
 
-		EddsaConfig {
-			scalar_mul_s,
-			scalar_mul_mh,
-			lt_eq,
-			point_add,
-			into_affine,
-			poseidon,
-			is_eq,
-			and,
-			temp,
-		}
+		EddsaConfig { common_eddsa, common, lt_eq, poseidon, temp }
 	}
 
 	/// Synthesize the circuit.
@@ -154,8 +121,15 @@ impl EddsaChip {
 		let is_lt_eq = lt_eq.synthesize(config.lt_eq, layouter.namespace(|| "s_lt_eq_suborder"))?;
 
 		// Cl = s * G
-		let scalar_mul1 = ScalarMulChip::new(b8_x, b8_y, one.clone(), self.s.clone(), self.s_bits);
-		let cl = scalar_mul1.synthesize(config.scalar_mul_s, layouter.namespace(|| "b_8 * s"))?;
+		let cl = CommonChip::<Fr>::scalar_mul::<252>(
+			b8_x,
+			b8_y,
+			one.clone(),
+			self.s.clone(),
+			self.s_bits,
+			config.common_eddsa,
+			layouter.namespace(|| "b_8 * s"),
+		)?;
 
 		// H(R || PK || M)
 		// Hashing R, public key and message composition.
@@ -171,50 +145,62 @@ impl EddsaChip {
 
 		// H(R || PK || M) * PK
 		// Scalar multiplication for the public key and hash.
-		let scalar_mul2 = ScalarMulChip::new(
+		let pk_h = CommonChip::<Fr>::scalar_mul::<256>(
 			self.pk_x.clone(),
 			self.pk_y.clone(),
 			one.clone(),
 			m_hash_res[0].clone(),
 			self.m_hash_bits,
-		);
-		let pk_h =
-			scalar_mul2.synthesize(config.scalar_mul_mh, layouter.namespace(|| "pk * m_hash"))?;
+			config.common_eddsa,
+			layouter.namespace(|| "pk * m_hash"),
+		)?;
 
 		// Cr = R + H(R || PK || M) * PK
-		let point_add = PointAddChip::new(
+		let cr = CommonChip::<Fr>::add_point(
 			self.big_r_x.clone(),
 			self.big_r_y.clone(),
 			one,
 			pk_h.0,
 			pk_h.1,
 			pk_h.2,
-		);
-		let cr = point_add.synthesize(config.point_add, layouter.namespace(|| "big_r + pk_h"))?;
+			config.common_eddsa,
+			layouter.namespace(|| "big_r + pk_h"),
+		)?;
 
 		// Converts two projective space points to their affine representation.
-		let into_affine1 = IntoAffineChip::new(cl.0, cl.1, cl.2);
-		let into_affine2 = IntoAffineChip::new(cr.0, cr.1, cr.2);
-
-		let cl_affine = into_affine1.synthesize(
-			config.into_affine.clone(),
+		let cl_affine = CommonChip::<Fr>::into_affine(
+			cl.0,
+			cl.1,
+			cl.2,
+			config.common_eddsa.clone(),
 			layouter.namespace(|| "cl_affine"),
 		)?;
-		let cr_affine =
-			into_affine2.synthesize(config.into_affine, layouter.namespace(|| "cr_affine"))?;
+		let cr_affine = CommonChip::<Fr>::into_affine(
+			cr.0,
+			cr.1,
+			cr.2,
+			config.common_eddsa,
+			layouter.namespace(|| "cr_affine"),
+		)?;
 
 		// Check if Clx == Crx and Cly == Cry.
-		let is_eq1 = IsEqualChip::new(cl_affine.0, cr_affine.0);
-		let is_eq2 = IsEqualChip::new(cl_affine.1, cr_affine.1);
-
-		let x_eq =
-			is_eq1.synthesize(config.is_eq.clone(), layouter.namespace(|| "point_x_equal"))?;
-		let y_eq = is_eq2.synthesize(config.is_eq, layouter.namespace(|| "point_y_equal"))?;
+		let x_eq = CommonChip::is_equal(
+			cl_affine.0,
+			cr_affine.0,
+			config.common.clone(),
+			layouter.namespace(|| "point_x_equal"),
+		)?;
+		let y_eq = CommonChip::is_equal(
+			cl_affine.1,
+			cr_affine.1,
+			config.common,
+			layouter.namespace(|| "point_y_equal"),
+		)?;
 
 		// Use And gate between x and y equality.
 		// If equal returns 1, else 0.
-		let and = AndChip::new(x_eq, y_eq);
-		let point_eq = and.synthesize(config.and, layouter.namespace(|| "point_eq"))?;
+		let point_eq =
+			CommonChip::and(x_eq, y_eq, config.common, layouter.namespace(|| "point_eq"))?;
 
 		// Enforce equality.
 		// If either one of them returns 0, the circuit will give an error.
@@ -239,7 +225,11 @@ impl EddsaChip {
 mod test {
 	use super::*;
 	use crate::{
-		eddsa::native::{ed_on_bn254::B8, sign, SecretKey},
+		eddsa::native::{
+			ed_on_bn254::{B8, G},
+			ops::add,
+			sign, SecretKey,
+		},
 		gadgets::{bits2num::to_bits, lt_eq::N_SHIFTED},
 		poseidon::native::Poseidon,
 		utils::{generate_params, prove_and_verify},
@@ -259,28 +249,34 @@ mod test {
 	type Hasher = Poseidon<Fr, 5, Params>;
 
 	#[derive(Clone)]
+	enum Gadgets {
+		Eddsa,
+		AddPoint,
+		IntoAffine,
+		ScalarMul,
+	}
+
+	#[derive(Clone)]
 	struct TestConfig {
 		eddsa: EddsaConfig,
+		common_eddsa: CommonEddsaConfig,
+		pub_ins: Column<Instance>,
 		temp: Column<Advice>,
 	}
 
 	#[derive(Clone)]
-	struct TestCircuit {
-		big_r_x: Fr,
-		big_r_y: Fr,
-		s: Fr,
-		pk_x: Fr,
-		pk_y: Fr,
-		m: Fr,
+	struct TestCircuit<const N: usize> {
+		inputs: [Fr; N],
+		gadget: Gadgets,
 	}
 
-	impl TestCircuit {
-		fn new(big_r_x: Fr, big_r_y: Fr, s: Fr, pk_x: Fr, pk_y: Fr, m: Fr) -> Self {
-			Self { big_r_x, big_r_y, s, pk_x, pk_y, m }
+	impl<const N: usize> TestCircuit<N> {
+		fn new(inputs: [Fr; N], gadget: Gadgets) -> Self {
+			Self { inputs, gadget }
 		}
 	}
 
-	impl Circuit<Fr> for TestCircuit {
+	impl<const N: usize> Circuit<Fr> for TestCircuit<N> {
 		type Config = TestConfig;
 		type FloorPlanner = SimpleFloorPlanner;
 
@@ -290,70 +286,109 @@ mod test {
 
 		fn configure(meta: &mut ConstraintSystem<Fr>) -> TestConfig {
 			let eddsa = EddsaChip::configure(meta);
+			let common_eddsa = CommonChip::<Fr>::configure_eddsa(meta);
+			let pub_ins = meta.instance_column();
 			let temp = meta.advice_column();
 
+			meta.enable_equality(pub_ins);
 			meta.enable_equality(temp);
 
-			TestConfig { eddsa, temp }
+			TestConfig { eddsa, common_eddsa, pub_ins, temp }
 		}
 
 		fn synthesize(
 			&self, config: TestConfig, mut layouter: impl Layouter<Fr>,
 		) -> Result<(), Error> {
-			let (big_r_x, big_r_y, s, pk_x, pk_y, m) = layouter.assign_region(
-				|| "temp",
-				|mut region: Region<'_, Fr>| {
-					let big_r_x_assigned = region.assign_advice(
-						|| "big_r_x",
-						config.temp,
-						0,
-						|| Value::known(self.big_r_x),
-					)?;
-					let big_r_y_assigned = region.assign_advice(
-						|| "big_r_y",
-						config.temp,
-						1,
-						|| Value::known(self.big_r_y),
-					)?;
-					let s_assigned =
-						region.assign_advice(|| "s", config.temp, 2, || Value::known(self.s))?;
-					let pk_x_assigned = region.assign_advice(
-						|| "pk_x",
-						config.temp,
-						3,
-						|| Value::known(self.pk_x),
-					)?;
-					let pk_y_assigned = region.assign_advice(
-						|| "pk_y",
-						config.temp,
-						4,
-						|| Value::known(self.pk_y),
-					)?;
-					let m_assigned =
-						region.assign_advice(|| "m", config.temp, 5, || Value::known(self.m))?;
-
-					Ok((
-						big_r_x_assigned, big_r_y_assigned, s_assigned, pk_x_assigned,
-						pk_y_assigned, m_assigned,
-					))
+			let mut items = Vec::new();
+			for i in 0..N {
+				items.push(layouter.assign_region(
+					|| "temp",
+					|mut region: Region<'_, Fr>| {
+						let x = region.assign_advice(
+							|| "temp_inputs",
+							config.temp,
+							i,
+							|| Value::known(self.inputs[i]),
+						)?;
+						Ok(x)
+					},
+				)?);
+			}
+			match self.gadget {
+				Gadgets::Eddsa => {
+					let s_bits = to_bits(self.inputs[2].to_bytes()).map(Fr::from);
+					let suborder_bits = to_bits(SUBORDER.to_bytes()).map(Fr::from);
+					let diff = self.inputs[2] + Fr::from_bytes(&N_SHIFTED).unwrap() - SUBORDER;
+					let diff_bits = to_bits(diff.to_bytes()).map(Fr::from);
+					let h_inputs = [
+						self.inputs[0], self.inputs[1], self.inputs[3], self.inputs[4],
+						self.inputs[5],
+					];
+					let res = Poseidon::<_, 5, Params>::new(h_inputs).permute()[0];
+					let m_hash_bits = to_bits(res.to_bytes()).map(Fr::from);
+					let eddsa = EddsaChip::new(
+						items[0].clone(),
+						items[1].clone(),
+						items[2].clone(),
+						items[3].clone(),
+						items[4].clone(),
+						items[5].clone(),
+						s_bits,
+						suborder_bits,
+						diff_bits,
+						m_hash_bits,
+					);
+					eddsa.synthesize(config.eddsa, layouter.namespace(|| "eddsa"))?;
 				},
-			)?;
-
-			let s_bits = to_bits(self.s.to_bytes()).map(Fr::from);
-			let suborder_bits = to_bits(SUBORDER.to_bytes()).map(Fr::from);
-			let diff = self.s + Fr::from_bytes(&N_SHIFTED).unwrap() - SUBORDER;
-			let diff_bits = to_bits(diff.to_bytes()).map(Fr::from);
-			let h_inputs = [self.big_r_x, self.big_r_y, self.pk_x, self.pk_y, self.m];
-			let res = Poseidon::<_, 5, Params>::new(h_inputs).permute()[0];
-			let m_hash_bits = to_bits(res.to_bytes()).map(Fr::from);
-			let eddsa = EddsaChip::new(
-				big_r_x, big_r_y, s, pk_x, pk_y, m, s_bits, suborder_bits, diff_bits, m_hash_bits,
-			);
-			eddsa.synthesize(config.eddsa, layouter.namespace(|| "eddsa"))?;
+				Gadgets::AddPoint => {
+					let (x, y, z) = CommonChip::<Fr>::add_point(
+						items[0].clone(),
+						items[1].clone(),
+						items[2].clone(),
+						items[3].clone(),
+						items[4].clone(),
+						items[5].clone(),
+						config.common_eddsa,
+						layouter.namespace(|| "add"),
+					)?;
+					layouter.constrain_instance(x.cell(), config.pub_ins, 0)?;
+					layouter.constrain_instance(y.cell(), config.pub_ins, 1)?;
+					layouter.constrain_instance(z.cell(), config.pub_ins, 2)?;
+				},
+				Gadgets::IntoAffine => {
+					let (x, y) = CommonChip::<Fr>::into_affine(
+						items[0].clone(),
+						items[1].clone(),
+						items[2].clone(),
+						config.common_eddsa,
+						layouter.namespace(|| "into_affine"),
+					)?;
+					layouter.constrain_instance(x.cell(), config.pub_ins, 0)?;
+					layouter.constrain_instance(y.cell(), config.pub_ins, 1)?;
+				},
+				Gadgets::ScalarMul => {
+					let value_bits = to_bits::<256>(self.inputs[3].to_bytes()).map(Fr::from);
+					let (x, y, z) = CommonChip::<Fr>::scalar_mul(
+						items[0].clone(),
+						items[1].clone(),
+						items[2].clone(),
+						items[3].clone(),
+						value_bits,
+						config.common_eddsa,
+						layouter.namespace(|| "scalar_mul"),
+					)?;
+					layouter.constrain_instance(x.cell(), config.pub_ins, 0)?;
+					layouter.constrain_instance(y.cell(), config.pub_ins, 1)?;
+					layouter.constrain_instance(z.cell(), config.pub_ins, 2)?;
+				},
+			}
 			Ok(())
 		}
 	}
 
+	// TEST CASES FOR THE EDDSA CIRCUIT
+	// In Eddsa test cases sending a dummy instance doesn't
+	// affect the circuit output because it is not constrained.
 	#[test]
 	fn test_eddsa() {
 		// Testing a valid case.
@@ -364,10 +399,14 @@ mod test {
 
 		let m = Fr::from_str_vartime("123456789012345678901234567890").unwrap();
 		let sig = sign(&sk, &pk, m);
-		let circuit = TestCircuit::new(sig.big_r.x, sig.big_r.y, sig.s, pk.0.x, pk.0.y, m);
+		let circuit = TestCircuit::new(
+			[sig.big_r.x, sig.big_r.y, sig.s, pk.0.x, pk.0.y, m],
+			Gadgets::Eddsa,
+		);
 
-		let k = 9;
-		let prover = MockProver::run(k, &circuit, vec![]).unwrap();
+		let k = 10;
+		let dummy_instance = vec![Fr::zero()];
+		let prover = MockProver::run(k, &circuit, vec![dummy_instance]).unwrap();
 		assert_eq!(prover.verify(), Ok(()));
 	}
 
@@ -385,10 +424,14 @@ mod test {
 		let m = Fr::from_str_vartime("123456789012345678901234567890").unwrap();
 		let mut sig = sign(&sk, &pk, m);
 		sig.big_r = B8.mul_scalar(&different_r.to_bytes()).affine();
-		let circuit = TestCircuit::new(sig.big_r.x, sig.big_r.y, sig.s, pk.0.x, pk.0.y, m);
+		let circuit = TestCircuit::new(
+			[sig.big_r.x, sig.big_r.y, sig.s, pk.0.x, pk.0.y, m],
+			Gadgets::Eddsa,
+		);
 
-		let k = 9;
-		let prover = MockProver::run(k, &circuit, vec![]).unwrap();
+		let k = 10;
+		let dummy_instance = vec![Fr::zero()];
+		let prover = MockProver::run(k, &circuit, vec![dummy_instance]).unwrap();
 		assert!(prover.verify().is_err());
 	}
 
@@ -403,10 +446,14 @@ mod test {
 		let m = Fr::from_str_vartime("123456789012345678901234567890").unwrap();
 		let mut sig = sign(&sk, &pk, m);
 		sig.s = sig.s.add(&Fr::from(1));
-		let circuit = TestCircuit::new(sig.big_r.x, sig.big_r.y, sig.s, pk.0.x, pk.0.y, m);
+		let circuit = TestCircuit::new(
+			[sig.big_r.x, sig.big_r.y, sig.s, pk.0.x, pk.0.y, m],
+			Gadgets::Eddsa,
+		);
 
-		let k = 9;
-		let prover = MockProver::run(k, &circuit, vec![]).unwrap();
+		let k = 10;
+		let dummy_instance = vec![Fr::zero()];
+		let prover = MockProver::run(k, &circuit, vec![dummy_instance]).unwrap();
 		assert!(prover.verify().is_err());
 	}
 
@@ -423,9 +470,13 @@ mod test {
 
 		let m = Fr::from_str_vartime("123456789012345678901234567890").unwrap();
 		let sig = sign(&sk1, &pk1, m);
-		let circuit = TestCircuit::new(sig.big_r.x, sig.big_r.y, sig.s, pk2.0.x, pk2.0.y, m);
-		let k = 9;
-		let prover = MockProver::run(k, &circuit, vec![]).unwrap();
+		let circuit = TestCircuit::new(
+			[sig.big_r.x, sig.big_r.y, sig.s, pk2.0.x, pk2.0.y, m],
+			Gadgets::Eddsa,
+		);
+		let k = 10;
+		let dummy_instance = vec![Fr::zero()];
+		let prover = MockProver::run(k, &circuit, vec![dummy_instance]).unwrap();
 		assert!(prover.verify().is_err());
 	}
 
@@ -441,10 +492,14 @@ mod test {
 		let m2 = Fr::from_str_vartime("123456789012345678901234567890123123").unwrap();
 
 		let sig = sign(&sk, &pk, m1);
-		let circuit = TestCircuit::new(sig.big_r.x, sig.big_r.y, sig.s, pk.0.x, pk.0.y, m2);
+		let circuit = TestCircuit::new(
+			[sig.big_r.x, sig.big_r.y, sig.s, pk.0.x, pk.0.y, m2],
+			Gadgets::Eddsa,
+		);
 
-		let k = 9;
-		let prover = MockProver::run(k, &circuit, vec![]).unwrap();
+		let k = 10;
+		let dummy_instance = vec![Fr::zero()];
+		let prover = MockProver::run(k, &circuit, vec![dummy_instance]).unwrap();
 
 		assert!(prover.verify().is_err());
 	}
@@ -458,12 +513,136 @@ mod test {
 
 		let m = Fr::from_str_vartime("123456789012345678901234567890").unwrap();
 		let sig = sign(&sk, &pk, m);
-		let circuit = TestCircuit::new(sig.big_r.x, sig.big_r.y, sig.s, pk.0.x, pk.0.y, m);
+		let circuit = TestCircuit::new(
+			[sig.big_r.x, sig.big_r.y, sig.s, pk.0.x, pk.0.y, m],
+			Gadgets::Eddsa,
+		);
+
+		let k = 10;
+		let rng = &mut rand::thread_rng();
+		let params = generate_params(k);
+		let dummy_instance = vec![Fr::zero()];
+		let res =
+			prove_and_verify::<Bn256, _, _>(params, circuit, &[&dummy_instance], rng).unwrap();
+
+		assert!(res);
+	}
+
+	// TEST CASES FOR THE ADD_POINT CIRCUIT
+	#[test]
+	fn should_add_point() {
+		// Testing a valid case.
+		let r = B8.projective();
+		let e = G.projective();
+		let (x_res, y_res, z_res) = add(r.x, r.y, r.z, e.x, e.y, e.z);
+		let circuit = TestCircuit::new([r.x, r.y, r.z, e.x, e.y, e.z], Gadgets::AddPoint);
+
+		let k = 7;
+		let pub_ins = vec![x_res, y_res, z_res];
+		let prover = MockProver::run(k, &circuit, vec![pub_ins]).unwrap();
+		assert_eq!(prover.verify(), Ok(()));
+	}
+
+	#[test]
+	fn should_add_point_production() {
+		let r = B8.projective();
+		let e = G.projective();
+		let (x_res, y_res, z_res) = add(r.x, r.y, r.z, e.x, e.y, e.z);
+		let circuit = TestCircuit::new([r.x, r.y, r.z, e.x, e.y, e.z], Gadgets::AddPoint);
 
 		let k = 9;
 		let rng = &mut rand::thread_rng();
 		let params = generate_params(k);
-		let res = prove_and_verify::<Bn256, _, _>(params, circuit, &[], rng).unwrap();
+		let pub_ins = [x_res, y_res, z_res];
+		let res = prove_and_verify::<Bn256, _, _>(params, circuit, &[&pub_ins], rng).unwrap();
+
+		assert!(res);
+	}
+
+	// TEST CASES FOR THE INTO_AFFINE CIRCUIT
+	#[test]
+	fn should_into_affine_point() {
+		// Testing a valid case.
+		let r = B8.projective();
+		let r_affine = r.affine();
+		let circuit = TestCircuit::new([r.x, r.y, r.z], Gadgets::IntoAffine);
+
+		let k = 7;
+		let pub_ins = vec![r_affine.x, r_affine.y];
+		let prover = MockProver::run(k, &circuit, vec![pub_ins]).unwrap();
+		assert_eq!(prover.verify(), Ok(()));
+	}
+
+	#[test]
+	fn should_into_affine_point_production() {
+		let r = B8.projective();
+		let r_affine = r.affine();
+		let circuit = TestCircuit::new([r.x, r.y, r.z], Gadgets::IntoAffine);
+
+		let k = 9;
+		let rng = &mut rand::thread_rng();
+		let params = generate_params(k);
+		let pub_ins = vec![r_affine.x, r_affine.y];
+		let res = prove_and_verify::<Bn256, _, _>(params, circuit, &[&pub_ins], rng).unwrap();
+
+		assert!(res);
+	}
+
+	//TEST CASES FOR THE SCALAR_MUL CIRCUIT
+	#[test]
+	fn should_mul_point_with_scalar() {
+		// Testing scalar as value 8.
+		let scalar = Fr::from(8);
+		let r = B8.projective();
+		let res = B8.mul_scalar(&scalar.to_bytes());
+		let circuit = TestCircuit::new([r.x, r.y, r.z, scalar], Gadgets::ScalarMul);
+
+		let k = 9;
+		let pub_ins = vec![res.x, res.y, res.z];
+		let prover = MockProver::run(k, &circuit, vec![pub_ins]).unwrap();
+		assert_eq!(prover.verify(), Ok(()));
+	}
+
+	#[test]
+	fn test_scalar_mul_zero() {
+		// Testing scalar as value 0.
+		let scalar = Fr::from(0);
+		let r = B8.projective();
+		let res = B8.mul_scalar(&scalar.to_bytes());
+		let circuit = TestCircuit::new([r.x, r.y, r.z, scalar], Gadgets::ScalarMul);
+
+		let k = 9;
+		let pub_ins = vec![res.x, res.y, res.z];
+		let prover = MockProver::run(k, &circuit, vec![pub_ins]).unwrap();
+		assert_eq!(prover.verify(), Ok(()));
+	}
+
+	#[test]
+	fn test_scalar_mul_one() {
+		// Testing scalar as value 1.
+		let scalar = Fr::from(1);
+		let r = B8.projective();
+		let res = B8.mul_scalar(&scalar.to_bytes());
+		let circuit = TestCircuit::new([r.x, r.y, r.z, scalar], Gadgets::ScalarMul);
+
+		let k = 9;
+		let pub_ins = vec![res.x, res.y, res.z];
+		let prover = MockProver::run(k, &circuit, vec![pub_ins]).unwrap();
+		assert_eq!(prover.verify(), Ok(()));
+	}
+
+	#[test]
+	fn should_mul_point_with_scalar_production() {
+		let scalar = Fr::from(8);
+		let r = B8.projective();
+		let res = B8.mul_scalar(&scalar.to_bytes());
+		let circuit = TestCircuit::new([r.x, r.y, r.z, scalar], Gadgets::ScalarMul);
+
+		let k = 9;
+		let rng = &mut rand::thread_rng();
+		let params = generate_params(k);
+		let pub_ins = [res.x, res.y, res.z];
+		let res = prove_and_verify::<Bn256, _, _>(params, circuit, &[&pub_ins], rng).unwrap();
 
 		assert!(res);
 	}

--- a/circuit/src/eddsa/mod.rs
+++ b/circuit/src/eddsa/mod.rs
@@ -25,7 +25,7 @@ use native::ed_on_bn254::{B8, SUBORDER};
 #[derive(Clone)]
 /// Configuration elements for the circuit are defined here.
 struct EddsaConfig {
-	/// Constructs common eddsa circuit elements.
+	/// Constructs eddsa gadgets circuit elements.
 	eddsa_gadgets: EddsaGadgetsConfig,
 	/// Constructs common circuit elements.
 	common: CommonConfig,

--- a/circuit/src/gadgets/bits2num.rs
+++ b/circuit/src/gadgets/bits2num.rs
@@ -15,7 +15,7 @@ pub fn to_bits<const B: usize>(num: [u8; 32]) -> [bool; B] {
 }
 
 /// Configuration elements for the circuit defined here.
-#[derive(Clone, Copy)]
+#[derive(Clone)]
 pub struct Bits2NumConfig {
 	/// Configures a column for the bits.
 	pub bits: Column<Advice>,

--- a/circuit/src/gadgets/bits2num.rs
+++ b/circuit/src/gadgets/bits2num.rs
@@ -15,7 +15,7 @@ pub fn to_bits<const B: usize>(num: [u8; 32]) -> [bool; B] {
 }
 
 /// Configuration elements for the circuit defined here.
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct Bits2NumConfig {
 	/// Configures a column for the bits.
 	pub bits: Column<Advice>,

--- a/circuit/src/gadgets/common.rs
+++ b/circuit/src/gadgets/common.rs
@@ -1,31 +1,15 @@
-use super::bits2num::{Bits2NumChip, Bits2NumConfig};
-use crate::eddsa::native::ops::{add_exp, add_value, double_exp, double_value};
-use halo2wrong::{
-	curves::bn256::Fr,
-	halo2::{
-		arithmetic::FieldExt,
-		circuit::{AssignedCell, Layouter, Region, Value},
-		plonk::{Advice, Column, ConstraintSystem, Error, Expression, Selector},
-		poly::Rotation,
-	},
+use halo2wrong::halo2::{
+	arithmetic::FieldExt,
+	circuit::{AssignedCell, Layouter, Region, Value},
+	plonk::{Advice, Column, ConstraintSystem, Error, Expression, Selector},
+	poly::Rotation,
 };
 use std::marker::PhantomData;
-
-#[derive(Copy, Clone)]
-/// Configuration elements for the circuit are defined here.
-pub struct CommonEddsaConfig {
-	/// Constructs bits2num circuit elements.
-	bits2num: Bits2NumConfig,
-	/// Configures columns for the eddsa advice.
-	eddsa_advice: [Column<Advice>; 7],
-	/// Configures fixed boolean values for each row of the circuit.
-	selectors: [Selector; 3],
-}
 
 #[derive(Copy, Clone, Debug)]
 /// Configuration elements for the circuit are defined here.
 pub struct CommonConfig {
-	/// Configures columns for the gadget advice.
+	/// Configures columns for the advice.
 	advice: [Column<Advice>; 3],
 	/// Configures fixed boolean values for each row of the circuit.
 	selectors: [Selector; 6],
@@ -38,8 +22,8 @@ pub struct CommonChip<F: FieldExt> {
 }
 
 impl<F: FieldExt> CommonChip<F> {
-	/// Configuration for the common gadget circuits.
-	pub fn configure_gadgets(meta: &mut ConstraintSystem<F>) -> CommonConfig {
+	/// Make the circuit config.
+	pub fn configure(meta: &mut ConstraintSystem<F>) -> CommonConfig {
 		let advice = [meta.advice_column(), meta.advice_column(), meta.advice_column()];
 		let selectors = [
 			meta.selector(),
@@ -188,131 +172,6 @@ impl<F: FieldExt> CommonChip<F> {
 		});
 
 		CommonConfig { advice, selectors }
-	}
-
-	/// Configuration for the common eddsa circuits.
-	pub fn configure_eddsa(meta: &mut ConstraintSystem<Fr>) -> CommonEddsaConfig {
-		let bits2num = Bits2NumChip::<_, 256>::configure(meta);
-		let eddsa_advice = [
-			meta.advice_column(),
-			meta.advice_column(),
-			meta.advice_column(),
-			meta.advice_column(),
-			meta.advice_column(),
-			meta.advice_column(),
-			meta.advice_column(),
-		];
-		let selectors = [meta.selector(), meta.selector(), meta.selector()];
-
-		eddsa_advice.map(|c| meta.enable_equality(c));
-
-		meta.create_gate("point_add", |v_cells| {
-			let s_exp = v_cells.query_selector(selectors[0]);
-
-			let r_x_exp = v_cells.query_advice(eddsa_advice[0], Rotation::cur());
-			let r_y_exp = v_cells.query_advice(eddsa_advice[1], Rotation::cur());
-			let r_z_exp = v_cells.query_advice(eddsa_advice[2], Rotation::cur());
-
-			let e_x_exp = v_cells.query_advice(eddsa_advice[3], Rotation::cur());
-			let e_y_exp = v_cells.query_advice(eddsa_advice[4], Rotation::cur());
-			let e_z_exp = v_cells.query_advice(eddsa_advice[5], Rotation::cur());
-
-			let r_x_next_exp = v_cells.query_advice(eddsa_advice[0], Rotation::next());
-			let r_y_next_exp = v_cells.query_advice(eddsa_advice[1], Rotation::next());
-			let r_z_next_exp = v_cells.query_advice(eddsa_advice[2], Rotation::next());
-
-			let (r_x3, r_y3, r_z3) = add_exp(
-				r_x_exp.clone(),
-				r_y_exp.clone(),
-				r_z_exp.clone(),
-				e_x_exp.clone(),
-				e_y_exp.clone(),
-				e_z_exp.clone(),
-			);
-
-			vec![
-				// Ensure the point addition of `r` and `e` is properly calculated.
-				s_exp.clone() * (r_x_next_exp - r_x3),
-				s_exp.clone() * (r_y_next_exp - r_y3),
-				s_exp.clone() * (r_z_next_exp - r_z3),
-			]
-		});
-
-		meta.create_gate("into_affine", |v_cells| {
-			let s_exp = v_cells.query_selector(selectors[1]);
-
-			let one = Expression::Constant(Fr::one());
-			let r_x_exp = v_cells.query_advice(eddsa_advice[0], Rotation::cur());
-			let r_y_exp = v_cells.query_advice(eddsa_advice[1], Rotation::cur());
-			let r_z_exp = v_cells.query_advice(eddsa_advice[2], Rotation::cur());
-
-			let r_x_affine_exp = v_cells.query_advice(eddsa_advice[3], Rotation::cur());
-			let r_y_affine_exp = v_cells.query_advice(eddsa_advice[4], Rotation::cur());
-			let r_z_invert_exp = v_cells.query_advice(eddsa_advice[5], Rotation::cur());
-
-			let affine_x = r_x_exp * r_z_invert_exp.clone();
-			let affine_y = r_y_exp * r_z_invert_exp.clone();
-
-			vec![
-				// Ensure the affine representation is properly calculated.
-				s_exp.clone() * (r_x_affine_exp - affine_x),
-				s_exp.clone() * (r_y_affine_exp - affine_y),
-				s_exp * (r_z_exp * r_z_invert_exp - one),
-			]
-		});
-
-		meta.create_gate("scalar_mul", |v_cells| {
-			let s_exp = v_cells.query_selector(selectors[2]);
-			let bit_exp = v_cells.query_advice(eddsa_advice[0], Rotation::cur());
-
-			let r_x_exp = v_cells.query_advice(eddsa_advice[1], Rotation::cur());
-			let r_y_exp = v_cells.query_advice(eddsa_advice[2], Rotation::cur());
-			let r_z_exp = v_cells.query_advice(eddsa_advice[3], Rotation::cur());
-
-			let e_x_exp = v_cells.query_advice(eddsa_advice[4], Rotation::cur());
-			let e_y_exp = v_cells.query_advice(eddsa_advice[5], Rotation::cur());
-			let e_z_exp = v_cells.query_advice(eddsa_advice[6], Rotation::cur());
-
-			let r_x_next_exp = v_cells.query_advice(eddsa_advice[1], Rotation::next());
-			let r_y_next_exp = v_cells.query_advice(eddsa_advice[2], Rotation::next());
-			let r_z_next_exp = v_cells.query_advice(eddsa_advice[3], Rotation::next());
-
-			let e_x_next_exp = v_cells.query_advice(eddsa_advice[4], Rotation::next());
-			let e_y_next_exp = v_cells.query_advice(eddsa_advice[5], Rotation::next());
-			let e_z_next_exp = v_cells.query_advice(eddsa_advice[6], Rotation::next());
-
-			let (r_x3, r_y3, r_z3) = add_exp(
-				r_x_exp.clone(),
-				r_y_exp.clone(),
-				r_z_exp.clone(),
-				e_x_exp.clone(),
-				e_y_exp.clone(),
-				e_z_exp.clone(),
-			);
-
-			let (e_x3, e_y3, e_z3) = double_exp(e_x_exp, e_y_exp, e_z_exp);
-
-			// Select the next value based on a `bit` -- see `select` gadget.
-			let selected_r_x =
-				bit_exp.clone() * (r_x3 - r_x_exp.clone()) - (r_x_next_exp - r_x_exp);
-			let selected_r_y =
-				bit_exp.clone() * (r_y3 - r_y_exp.clone()) - (r_y_next_exp - r_y_exp);
-			let selected_r_z =
-				bit_exp.clone() * (r_z3 - r_z_exp.clone()) - (r_z_next_exp - r_z_exp);
-
-			vec![
-				// Ensure the point addition of `r` and `e` is properly calculated.
-				s_exp.clone() * selected_r_x,
-				s_exp.clone() * selected_r_y,
-				s_exp.clone() * selected_r_z,
-				// Ensure the `e` doubling is properly calculated.
-				s_exp.clone() * (e_x_next_exp - e_x3),
-				s_exp.clone() * (e_y_next_exp - e_y3),
-				s_exp * (e_z_next_exp - e_z3),
-			]
-		});
-
-		CommonEddsaConfig { bits2num, eddsa_advice, selectors }
 	}
 
 	/// Synthesize the and circuit.
@@ -489,251 +348,6 @@ impl<F: FieldExt> CommonChip<F> {
 			},
 		)
 	}
-
-	/// Synthesize the add_point circuit.
-	pub fn add_point(
-		// Assigns a cell for the r_x.
-		r_x: AssignedCell<Fr, Fr>,
-		// Assigns a cell for the r_y.
-		r_y: AssignedCell<Fr, Fr>,
-		// Assigns a cell for the r_z.
-		r_z: AssignedCell<Fr, Fr>,
-		// Assigns a cell for the e_x.
-		e_x: AssignedCell<Fr, Fr>,
-		// Assigns a cell for the e_y.
-		e_y: AssignedCell<Fr, Fr>,
-		// Assigns a cell for the e_z.
-		e_z: AssignedCell<Fr, Fr>,
-		config: CommonEddsaConfig,
-		mut layouter: impl Layouter<Fr>,
-	) -> Result<
-		(
-			AssignedCell<Fr, Fr>,
-			AssignedCell<Fr, Fr>,
-			AssignedCell<Fr, Fr>,
-		),
-		Error,
-	> {
-		layouter.assign_region(
-			|| "add",
-			|mut region: Region<'_, Fr>| {
-				config.selectors[0].enable(&mut region, 0)?;
-
-				let r_x = r_x.copy_advice(|| "r_x", &mut region, config.eddsa_advice[0], 0)?;
-				let r_y = r_y.copy_advice(|| "r_y", &mut region, config.eddsa_advice[1], 0)?;
-				let r_z = r_z.copy_advice(|| "r_z", &mut region, config.eddsa_advice[2], 0)?;
-				let e_x = e_x.copy_advice(|| "e_x", &mut region, config.eddsa_advice[3], 0)?;
-				let e_y = e_y.copy_advice(|| "e_y", &mut region, config.eddsa_advice[4], 0)?;
-				let e_z = e_z.copy_advice(|| "e_z", &mut region, config.eddsa_advice[5], 0)?;
-
-				// Add `r` and `e`.
-				let (r_x3, r_y3, r_z3) = add_value(
-					r_x.value_field(),
-					r_y.value_field(),
-					r_z.value_field(),
-					e_x.value_field(),
-					e_y.value_field(),
-					e_z.value_field(),
-				);
-
-				let r_x_res = region.assign_advice(
-					|| "r_x",
-					config.eddsa_advice[0],
-					1,
-					|| r_x3.evaluate(),
-				)?;
-				let r_y_res = region.assign_advice(
-					|| "r_y",
-					config.eddsa_advice[1],
-					1,
-					|| r_y3.evaluate(),
-				)?;
-				let r_z_res = region.assign_advice(
-					|| "r_z",
-					config.eddsa_advice[2],
-					1,
-					|| r_z3.evaluate(),
-				)?;
-
-				Ok((r_x_res, r_y_res, r_z_res))
-			},
-		)
-	}
-
-	/// Synthesize the into_affine circuit.
-	pub fn into_affine(
-		// Assigns a cell for the r_x.
-		r_x: AssignedCell<Fr, Fr>,
-		// Assigns a cell for the r_y.
-		r_y: AssignedCell<Fr, Fr>,
-		// Assigns a cell for the r_z.
-		r_z: AssignedCell<Fr, Fr>,
-		config: CommonEddsaConfig,
-		mut layouter: impl Layouter<Fr>,
-	) -> Result<(AssignedCell<Fr, Fr>, AssignedCell<Fr, Fr>), Error> {
-		layouter.assign_region(
-			|| "into_affine",
-			|mut region: Region<'_, Fr>| {
-				config.selectors[1].enable(&mut region, 0)?;
-
-				r_x.copy_advice(|| "r_x", &mut region, config.eddsa_advice[0], 0)?;
-				r_y.copy_advice(|| "r_y", &mut region, config.eddsa_advice[1], 0)?;
-				r_z.copy_advice(|| "r_z", &mut region, config.eddsa_advice[2], 0)?;
-
-				// Calculating affine representation for the point.
-				// Divide both points with the third dimension to get the affine point.
-				// Shrinking a line to a dot is why some projective
-				// space coordinates returns to the same affine points.
-				let z_invert = r_z.value_field().invert();
-				let r_x_affine = r_x.value_field() * z_invert;
-				let r_y_affine = r_y.value_field() * z_invert;
-
-				let x = region.assign_advice(
-					|| "r_x_affine",
-					config.eddsa_advice[3],
-					0,
-					|| r_x_affine.evaluate(),
-				)?;
-				let y = region.assign_advice(
-					|| "r_y_affine",
-					config.eddsa_advice[4],
-					0,
-					|| r_y_affine.evaluate(),
-				)?;
-				region.assign_advice(
-					|| "r_z_invert",
-					config.eddsa_advice[5],
-					0,
-					|| z_invert.evaluate(),
-				)?;
-
-				Ok((x, y))
-			},
-		)
-	}
-
-	/// Synthesize the scalar_mul circuit.
-	pub fn scalar_mul<const B: usize>(
-		// Assigns a cell for the e_x.
-		e_x: AssignedCell<Fr, Fr>,
-		// Assigns a cell for the e_y.
-		e_y: AssignedCell<Fr, Fr>,
-		// Assigns a cell for the e_z.
-		e_z: AssignedCell<Fr, Fr>,
-		// Assigns a cell for the value.
-		value: AssignedCell<Fr, Fr>,
-		// Constructs an array for the value bits.
-		value_bits: [Fr; B],
-		config: CommonEddsaConfig,
-		mut layouter: impl Layouter<Fr>,
-	) -> Result<
-		(
-			AssignedCell<Fr, Fr>,
-			AssignedCell<Fr, Fr>,
-			AssignedCell<Fr, Fr>,
-		),
-		Error,
-	> {
-		let bits2num = Bits2NumChip::new(value.clone(), value_bits);
-		let bits = bits2num.synthesize(config.bits2num, layouter.namespace(|| "bits2num"))?;
-
-		layouter.assign_region(
-			|| "scalar_mul",
-			|mut region: Region<'_, Fr>| {
-				for i in 0..bits.len() {
-					bits[i].copy_advice(|| "bit", &mut region, config.eddsa_advice[0], i)?;
-				}
-
-				let mut r_x = region.assign_advice_from_constant(
-					|| "r_x_0",
-					config.eddsa_advice[1],
-					0,
-					Fr::zero(),
-				)?;
-				let mut r_y = region.assign_advice_from_constant(
-					|| "r_y_0",
-					config.eddsa_advice[2],
-					0,
-					Fr::one(),
-				)?;
-				let mut r_z = region.assign_advice_from_constant(
-					|| "r_z_0",
-					config.eddsa_advice[3],
-					0,
-					Fr::one(),
-				)?;
-
-				let mut e_x = e_x.copy_advice(|| "e_x", &mut region, config.eddsa_advice[4], 0)?;
-				let mut e_y = e_y.copy_advice(|| "e_y", &mut region, config.eddsa_advice[5], 0)?;
-				let mut e_z = e_z.copy_advice(|| "e_z", &mut region, config.eddsa_advice[6], 0)?;
-
-				// Double and add operation.
-				for i in 0..value_bits.len() {
-					config.selectors[2].enable(&mut region, i)?;
-
-					// Add `r` and `e`.
-					let (r_x3, r_y3, r_z3) = add_value(
-						r_x.value_field(),
-						r_y.value_field(),
-						r_z.value_field(),
-						e_x.value_field(),
-						e_y.value_field(),
-						e_z.value_field(),
-					);
-
-					// Double `e`.
-					let (e_x3, e_y3, e_z3) =
-						double_value(e_x.value_field(), e_y.value_field(), e_z.value_field());
-
-					let (r_x_next, r_y_next, r_z_next) = if value_bits[i] == Fr::one() {
-						(r_x3, r_y3, r_z3)
-					} else {
-						(r_x.value_field(), r_y.value_field(), r_z.value_field())
-					};
-
-					r_x = region.assign_advice(
-						|| "r_x",
-						config.eddsa_advice[1],
-						i + 1,
-						|| r_x_next.evaluate(),
-					)?;
-					r_y = region.assign_advice(
-						|| "r_y",
-						config.eddsa_advice[2],
-						i + 1,
-						|| r_y_next.evaluate(),
-					)?;
-					r_z = region.assign_advice(
-						|| "r_z",
-						config.eddsa_advice[3],
-						i + 1,
-						|| r_z_next.evaluate(),
-					)?;
-
-					e_x = region.assign_advice(
-						|| "e_x",
-						config.eddsa_advice[4],
-						i + 1,
-						|| e_x3.evaluate(),
-					)?;
-					e_y = region.assign_advice(
-						|| "e_y",
-						config.eddsa_advice[5],
-						i + 1,
-						|| e_y3.evaluate(),
-					)?;
-					e_z = region.assign_advice(
-						|| "e_z",
-						config.eddsa_advice[6],
-						i + 1,
-						|| e_z3.evaluate(),
-					)?;
-				}
-
-				Ok((r_x, r_y, r_z))
-			},
-		)
-	}
 }
 
 #[cfg(test)]
@@ -787,7 +401,7 @@ mod test {
 		}
 
 		fn configure(meta: &mut ConstraintSystem<F>) -> TestConfig {
-			let common = CommonChip::configure_gadgets(meta);
+			let common = CommonChip::configure(meta);
 			let temp = meta.advice_column();
 			let pub_ins = meta.instance_column();
 			meta.enable_equality(temp);
@@ -933,7 +547,7 @@ mod test {
 	}
 
 	// TEST CASES FOR THE IS_BOOL CIRCUIT
-	// In IsBool test cases sending a dummy instance doesn't
+	// In a IsBool test case sending a dummy instance doesn't
 	// affect the circuit output because it is not constrained.
 	#[test]
 	fn test_is_bool_value_zero() {

--- a/circuit/src/gadgets/common.rs
+++ b/circuit/src/gadgets/common.rs
@@ -1,15 +1,31 @@
-use halo2wrong::halo2::{
-	arithmetic::FieldExt,
-	circuit::{AssignedCell, Layouter, Region, Value},
-	plonk::{Advice, Column, ConstraintSystem, Error, Expression, Selector},
-	poly::Rotation,
+use super::bits2num::{Bits2NumChip, Bits2NumConfig};
+use crate::eddsa::native::ops::{add_exp, add_value, double_exp, double_value};
+use halo2wrong::{
+	curves::bn256::Fr,
+	halo2::{
+		arithmetic::FieldExt,
+		circuit::{AssignedCell, Layouter, Region, Value},
+		plonk::{Advice, Column, ConstraintSystem, Error, Expression, Selector},
+		poly::Rotation,
+	},
 };
 use std::marker::PhantomData;
+
+#[derive(Copy, Clone)]
+/// Configuration elements for the circuit are defined here.
+pub struct CommonEddsaConfig {
+	/// Constructs bits2num circuit elements.
+	bits2num: Bits2NumConfig,
+	/// Configures columns for the eddsa advice.
+	eddsa_advice: [Column<Advice>; 7],
+	/// Configures fixed boolean values for each row of the circuit.
+	selectors: [Selector; 3],
+}
 
 #[derive(Copy, Clone, Debug)]
 /// Configuration elements for the circuit are defined here.
 pub struct CommonConfig {
-	/// Configures columns for the advice.
+	/// Configures columns for the gadget advice.
 	advice: [Column<Advice>; 3],
 	/// Configures fixed boolean values for each row of the circuit.
 	selectors: [Selector; 6],
@@ -22,8 +38,8 @@ pub struct CommonChip<F: FieldExt> {
 }
 
 impl<F: FieldExt> CommonChip<F> {
-	/// Make the circuit config.
-	pub fn configure(meta: &mut ConstraintSystem<F>) -> CommonConfig {
+	/// Configuration for the common gadget circuits.
+	pub fn configure_gadgets(meta: &mut ConstraintSystem<F>) -> CommonConfig {
 		let advice = [meta.advice_column(), meta.advice_column(), meta.advice_column()];
 		let selectors = [
 			meta.selector(),
@@ -172,6 +188,131 @@ impl<F: FieldExt> CommonChip<F> {
 		});
 
 		CommonConfig { advice, selectors }
+	}
+
+	/// Configuration for the common eddsa circuits.
+	pub fn configure_eddsa(meta: &mut ConstraintSystem<Fr>) -> CommonEddsaConfig {
+		let bits2num = Bits2NumChip::<_, 256>::configure(meta);
+		let eddsa_advice = [
+			meta.advice_column(),
+			meta.advice_column(),
+			meta.advice_column(),
+			meta.advice_column(),
+			meta.advice_column(),
+			meta.advice_column(),
+			meta.advice_column(),
+		];
+		let selectors = [meta.selector(), meta.selector(), meta.selector()];
+
+		eddsa_advice.map(|c| meta.enable_equality(c));
+
+		meta.create_gate("point_add", |v_cells| {
+			let s_exp = v_cells.query_selector(selectors[0]);
+
+			let r_x_exp = v_cells.query_advice(eddsa_advice[0], Rotation::cur());
+			let r_y_exp = v_cells.query_advice(eddsa_advice[1], Rotation::cur());
+			let r_z_exp = v_cells.query_advice(eddsa_advice[2], Rotation::cur());
+
+			let e_x_exp = v_cells.query_advice(eddsa_advice[3], Rotation::cur());
+			let e_y_exp = v_cells.query_advice(eddsa_advice[4], Rotation::cur());
+			let e_z_exp = v_cells.query_advice(eddsa_advice[5], Rotation::cur());
+
+			let r_x_next_exp = v_cells.query_advice(eddsa_advice[0], Rotation::next());
+			let r_y_next_exp = v_cells.query_advice(eddsa_advice[1], Rotation::next());
+			let r_z_next_exp = v_cells.query_advice(eddsa_advice[2], Rotation::next());
+
+			let (r_x3, r_y3, r_z3) = add_exp(
+				r_x_exp.clone(),
+				r_y_exp.clone(),
+				r_z_exp.clone(),
+				e_x_exp.clone(),
+				e_y_exp.clone(),
+				e_z_exp.clone(),
+			);
+
+			vec![
+				// Ensure the point addition of `r` and `e` is properly calculated.
+				s_exp.clone() * (r_x_next_exp - r_x3),
+				s_exp.clone() * (r_y_next_exp - r_y3),
+				s_exp.clone() * (r_z_next_exp - r_z3),
+			]
+		});
+
+		meta.create_gate("into_affine", |v_cells| {
+			let s_exp = v_cells.query_selector(selectors[1]);
+
+			let one = Expression::Constant(Fr::one());
+			let r_x_exp = v_cells.query_advice(eddsa_advice[0], Rotation::cur());
+			let r_y_exp = v_cells.query_advice(eddsa_advice[1], Rotation::cur());
+			let r_z_exp = v_cells.query_advice(eddsa_advice[2], Rotation::cur());
+
+			let r_x_affine_exp = v_cells.query_advice(eddsa_advice[0], Rotation::next());
+			let r_y_affine_exp = v_cells.query_advice(eddsa_advice[1], Rotation::next());
+			let r_z_invert_exp = v_cells.query_advice(eddsa_advice[2], Rotation::next());
+
+			let affine_x = r_x_exp * r_z_invert_exp.clone();
+			let affine_y = r_y_exp * r_z_invert_exp.clone();
+
+			vec![
+				// Ensure the affine calculation properly calculated.
+				s_exp.clone() * (r_x_affine_exp - affine_x),
+				s_exp.clone() * (r_y_affine_exp - affine_y),
+				s_exp * (r_z_exp * r_z_invert_exp - one),
+			]
+		});
+
+		meta.create_gate("scalar_mul", |v_cells| {
+			let s_exp = v_cells.query_selector(selectors[2]);
+			let bit_exp = v_cells.query_advice(eddsa_advice[0], Rotation::cur());
+
+			let r_x_exp = v_cells.query_advice(eddsa_advice[1], Rotation::cur());
+			let r_y_exp = v_cells.query_advice(eddsa_advice[2], Rotation::cur());
+			let r_z_exp = v_cells.query_advice(eddsa_advice[3], Rotation::cur());
+
+			let e_x_exp = v_cells.query_advice(eddsa_advice[4], Rotation::cur());
+			let e_y_exp = v_cells.query_advice(eddsa_advice[5], Rotation::cur());
+			let e_z_exp = v_cells.query_advice(eddsa_advice[6], Rotation::cur());
+
+			let r_x_next_exp = v_cells.query_advice(eddsa_advice[1], Rotation::next());
+			let r_y_next_exp = v_cells.query_advice(eddsa_advice[2], Rotation::next());
+			let r_z_next_exp = v_cells.query_advice(eddsa_advice[3], Rotation::next());
+
+			let e_x_next_exp = v_cells.query_advice(eddsa_advice[4], Rotation::next());
+			let e_y_next_exp = v_cells.query_advice(eddsa_advice[5], Rotation::next());
+			let e_z_next_exp = v_cells.query_advice(eddsa_advice[6], Rotation::next());
+
+			let (r_x3, r_y3, r_z3) = add_exp(
+				r_x_exp.clone(),
+				r_y_exp.clone(),
+				r_z_exp.clone(),
+				e_x_exp.clone(),
+				e_y_exp.clone(),
+				e_z_exp.clone(),
+			);
+
+			let (e_x3, e_y3, e_z3) = double_exp(e_x_exp, e_y_exp, e_z_exp);
+
+			// Select the next value based on a `bit` -- see `select` gadget.
+			let selected_r_x =
+				bit_exp.clone() * (r_x3 - r_x_exp.clone()) - (r_x_next_exp - r_x_exp);
+			let selected_r_y =
+				bit_exp.clone() * (r_y3 - r_y_exp.clone()) - (r_y_next_exp - r_y_exp);
+			let selected_r_z =
+				bit_exp.clone() * (r_z3 - r_z_exp.clone()) - (r_z_next_exp - r_z_exp);
+
+			vec![
+				// Ensure the point addition of `r` and `e` is properly calculated.
+				s_exp.clone() * selected_r_x,
+				s_exp.clone() * selected_r_y,
+				s_exp.clone() * selected_r_z,
+				// Ensure the `e` doubling is properly calculated.
+				s_exp.clone() * (e_x_next_exp - e_x3),
+				s_exp.clone() * (e_y_next_exp - e_y3),
+				s_exp * (e_z_next_exp - e_z3),
+			]
+		});
+
+		CommonEddsaConfig { bits2num, eddsa_advice, selectors }
 	}
 
 	/// Synthesize the and circuit.
@@ -348,6 +489,251 @@ impl<F: FieldExt> CommonChip<F> {
 			},
 		)
 	}
+
+	/// Synthesize the add_point circuit.
+	pub fn add_point(
+		// Assigns a cell for the r_x.
+		r_x: AssignedCell<Fr, Fr>,
+		// Assigns a cell for the r_y.
+		r_y: AssignedCell<Fr, Fr>,
+		// Assigns a cell for the r_z.
+		r_z: AssignedCell<Fr, Fr>,
+		// Assigns a cell for the e_x.
+		e_x: AssignedCell<Fr, Fr>,
+		// Assigns a cell for the e_y.
+		e_y: AssignedCell<Fr, Fr>,
+		// Assigns a cell for the e_z.
+		e_z: AssignedCell<Fr, Fr>,
+		config: CommonEddsaConfig,
+		mut layouter: impl Layouter<Fr>,
+	) -> Result<
+		(
+			AssignedCell<Fr, Fr>,
+			AssignedCell<Fr, Fr>,
+			AssignedCell<Fr, Fr>,
+		),
+		Error,
+	> {
+		layouter.assign_region(
+			|| "add",
+			|mut region: Region<'_, Fr>| {
+				config.selectors[0].enable(&mut region, 0)?;
+
+				let r_x = r_x.copy_advice(|| "r_x", &mut region, config.eddsa_advice[0], 0)?;
+				let r_y = r_y.copy_advice(|| "r_y", &mut region, config.eddsa_advice[1], 0)?;
+				let r_z = r_z.copy_advice(|| "r_z", &mut region, config.eddsa_advice[2], 0)?;
+				let e_x = e_x.copy_advice(|| "e_x", &mut region, config.eddsa_advice[3], 0)?;
+				let e_y = e_y.copy_advice(|| "e_y", &mut region, config.eddsa_advice[4], 0)?;
+				let e_z = e_z.copy_advice(|| "e_z", &mut region, config.eddsa_advice[5], 0)?;
+
+				// Add `r` and `e`.
+				let (r_x3, r_y3, r_z3) = add_value(
+					r_x.value_field(),
+					r_y.value_field(),
+					r_z.value_field(),
+					e_x.value_field(),
+					e_y.value_field(),
+					e_z.value_field(),
+				);
+
+				let r_x_res = region.assign_advice(
+					|| "r_x",
+					config.eddsa_advice[0],
+					1,
+					|| r_x3.evaluate(),
+				)?;
+				let r_y_res = region.assign_advice(
+					|| "r_y",
+					config.eddsa_advice[1],
+					1,
+					|| r_y3.evaluate(),
+				)?;
+				let r_z_res = region.assign_advice(
+					|| "r_z",
+					config.eddsa_advice[2],
+					1,
+					|| r_z3.evaluate(),
+				)?;
+
+				Ok((r_x_res, r_y_res, r_z_res))
+			},
+		)
+	}
+
+	/// Synthesize the into_affine circuit.
+	pub fn into_affine(
+		// Assigns a cell for the r_x.
+		r_x: AssignedCell<Fr, Fr>,
+		// Assigns a cell for the r_y.
+		r_y: AssignedCell<Fr, Fr>,
+		// Assigns a cell for the r_z.
+		r_z: AssignedCell<Fr, Fr>,
+		config: CommonEddsaConfig,
+		mut layouter: impl Layouter<Fr>,
+	) -> Result<(AssignedCell<Fr, Fr>, AssignedCell<Fr, Fr>), Error> {
+		layouter.assign_region(
+			|| "into_affine",
+			|mut region: Region<'_, Fr>| {
+				config.selectors[1].enable(&mut region, 0)?;
+
+				r_x.copy_advice(|| "r_x", &mut region, config.eddsa_advice[0], 0)?;
+				r_y.copy_advice(|| "r_y", &mut region, config.eddsa_advice[1], 0)?;
+				r_z.copy_advice(|| "r_z", &mut region, config.eddsa_advice[2], 0)?;
+
+				// Calculating affine representation for the point.
+				// Divide both points with the third dimension to get the affine point.
+				// Shrinking a line to a dot is why some projective
+				// space coordinates returns to the same affine points.
+				let z_invert = r_z.value_field().invert();
+				let r_x_affine = r_x.value_field() * z_invert;
+				let r_y_affine = r_y.value_field() * z_invert;
+
+				let x = region.assign_advice(
+					|| "r_x_affine",
+					config.eddsa_advice[0],
+					1,
+					|| r_x_affine.evaluate(),
+				)?;
+				let y = region.assign_advice(
+					|| "r_y_affine",
+					config.eddsa_advice[1],
+					1,
+					|| r_y_affine.evaluate(),
+				)?;
+				region.assign_advice(
+					|| "r_z_invert",
+					config.eddsa_advice[2],
+					1,
+					|| z_invert.evaluate(),
+				)?;
+
+				Ok((x, y))
+			},
+		)
+	}
+
+	/// Synthesize the scalar_mul circuit.
+	pub fn scalar_mul<const B: usize>(
+		// Assigns a cell for the e_x.
+		e_x: AssignedCell<Fr, Fr>,
+		// Assigns a cell for the e_y.
+		e_y: AssignedCell<Fr, Fr>,
+		// Assigns a cell for the e_z.
+		e_z: AssignedCell<Fr, Fr>,
+		// Assigns a cell for the value.
+		value: AssignedCell<Fr, Fr>,
+		// Constructs an array for the value bits.
+		value_bits: [Fr; B],
+		config: CommonEddsaConfig,
+		mut layouter: impl Layouter<Fr>,
+	) -> Result<
+		(
+			AssignedCell<Fr, Fr>,
+			AssignedCell<Fr, Fr>,
+			AssignedCell<Fr, Fr>,
+		),
+		Error,
+	> {
+		let bits2num = Bits2NumChip::new(value.clone(), value_bits);
+		let bits = bits2num.synthesize(config.bits2num, layouter.namespace(|| "bits2num"))?;
+
+		layouter.assign_region(
+			|| "scalar_mul",
+			|mut region: Region<'_, Fr>| {
+				for i in 0..bits.len() {
+					bits[i].copy_advice(|| "bit", &mut region, config.eddsa_advice[0], i)?;
+				}
+
+				let mut r_x = region.assign_advice_from_constant(
+					|| "r_x_0",
+					config.eddsa_advice[1],
+					0,
+					Fr::zero(),
+				)?;
+				let mut r_y = region.assign_advice_from_constant(
+					|| "r_y_0",
+					config.eddsa_advice[2],
+					0,
+					Fr::one(),
+				)?;
+				let mut r_z = region.assign_advice_from_constant(
+					|| "r_z_0",
+					config.eddsa_advice[3],
+					0,
+					Fr::one(),
+				)?;
+
+				let mut e_x = e_x.copy_advice(|| "e_x", &mut region, config.eddsa_advice[4], 0)?;
+				let mut e_y = e_y.copy_advice(|| "e_y", &mut region, config.eddsa_advice[5], 0)?;
+				let mut e_z = e_z.copy_advice(|| "e_z", &mut region, config.eddsa_advice[6], 0)?;
+
+				// Double and add operation.
+				for i in 0..value_bits.len() {
+					config.selectors[2].enable(&mut region, i)?;
+
+					// Add `r` and `e`.
+					let (r_x3, r_y3, r_z3) = add_value(
+						r_x.value_field(),
+						r_y.value_field(),
+						r_z.value_field(),
+						e_x.value_field(),
+						e_y.value_field(),
+						e_z.value_field(),
+					);
+
+					// Double `e`.
+					let (e_x3, e_y3, e_z3) =
+						double_value(e_x.value_field(), e_y.value_field(), e_z.value_field());
+
+					let (r_x_next, r_y_next, r_z_next) = if value_bits[i] == Fr::one() {
+						(r_x3, r_y3, r_z3)
+					} else {
+						(r_x.value_field(), r_y.value_field(), r_z.value_field())
+					};
+
+					r_x = region.assign_advice(
+						|| "r_x",
+						config.eddsa_advice[1],
+						i + 1,
+						|| r_x_next.evaluate(),
+					)?;
+					r_y = region.assign_advice(
+						|| "r_y",
+						config.eddsa_advice[2],
+						i + 1,
+						|| r_y_next.evaluate(),
+					)?;
+					r_z = region.assign_advice(
+						|| "r_z",
+						config.eddsa_advice[3],
+						i + 1,
+						|| r_z_next.evaluate(),
+					)?;
+
+					e_x = region.assign_advice(
+						|| "e_x",
+						config.eddsa_advice[4],
+						i + 1,
+						|| e_x3.evaluate(),
+					)?;
+					e_y = region.assign_advice(
+						|| "e_y",
+						config.eddsa_advice[5],
+						i + 1,
+						|| e_y3.evaluate(),
+					)?;
+					e_z = region.assign_advice(
+						|| "e_z",
+						config.eddsa_advice[6],
+						i + 1,
+						|| e_z3.evaluate(),
+					)?;
+				}
+
+				Ok((r_x, r_y, r_z))
+			},
+		)
+	}
 }
 
 #[cfg(test)]
@@ -401,7 +787,7 @@ mod test {
 		}
 
 		fn configure(meta: &mut ConstraintSystem<F>) -> TestConfig {
-			let common = CommonChip::configure(meta);
+			let common = CommonChip::configure_gadgets(meta);
 			let temp = meta.advice_column();
 			let pub_ins = meta.instance_column();
 			meta.enable_equality(temp);
@@ -488,7 +874,7 @@ mod test {
 		}
 	}
 
-	// AND CIRCUIT TESTS
+	// TEST CASES FOR THE AND CIRCUIT
 	#[test]
 	fn test_and_x1_y1() {
 		// Testing x = 1 and y = 1.
@@ -546,7 +932,9 @@ mod test {
 		assert!(res);
 	}
 
-	// IS_BOOL CIRCUIT TESTS
+	// TEST CASES FOR THE IS_BOOL CIRCUIT
+	// In IsBool test cases sending a dummy instance doesn't
+	// affect the circuit output because it is not constrained.
 	#[test]
 	fn test_is_bool_value_zero() {
 		// Testing input zero as value.
@@ -594,7 +982,7 @@ mod test {
 		assert!(res);
 	}
 
-	// IS_EQUAL CIRCUIT TESTS
+	// TEST CASES FOR THE IS_EQUAL CIRCUIT
 	#[test]
 	fn test_is_equal() {
 		// Testing equal values.
@@ -629,7 +1017,7 @@ mod test {
 		assert!(res);
 	}
 
-	// IS_ZERO CIRCUIT TESTS
+	// TEST CASES FOR THE IS_ZERO CIRCUIT
 	#[test]
 	fn test_is_zero() {
 		// Testing zero as value.
@@ -664,7 +1052,7 @@ mod test {
 		assert!(res);
 	}
 
-	// MUL CIRCUIT TESTS
+	// TEST CASES FOR THE MUL CIRCUIT
 	#[test]
 	fn test_mul() {
 		// Testing x = 5 and y = 2.
@@ -711,7 +1099,7 @@ mod test {
 		assert!(res);
 	}
 
-	// SELECT CIRCUIT TESTS
+	// TEST CASES FOR THE SELECT CIRCUIT
 	#[test]
 	fn test_select() {
 		// Testing bit = 0.

--- a/circuit/src/gadgets/common.rs
+++ b/circuit/src/gadgets/common.rs
@@ -246,15 +246,15 @@ impl<F: FieldExt> CommonChip<F> {
 			let r_y_exp = v_cells.query_advice(eddsa_advice[1], Rotation::cur());
 			let r_z_exp = v_cells.query_advice(eddsa_advice[2], Rotation::cur());
 
-			let r_x_affine_exp = v_cells.query_advice(eddsa_advice[0], Rotation::next());
-			let r_y_affine_exp = v_cells.query_advice(eddsa_advice[1], Rotation::next());
-			let r_z_invert_exp = v_cells.query_advice(eddsa_advice[2], Rotation::next());
+			let r_x_affine_exp = v_cells.query_advice(eddsa_advice[3], Rotation::cur());
+			let r_y_affine_exp = v_cells.query_advice(eddsa_advice[4], Rotation::cur());
+			let r_z_invert_exp = v_cells.query_advice(eddsa_advice[5], Rotation::cur());
 
 			let affine_x = r_x_exp * r_z_invert_exp.clone();
 			let affine_y = r_y_exp * r_z_invert_exp.clone();
 
 			vec![
-				// Ensure the affine calculation properly calculated.
+				// Ensure the affine representation is properly calculated.
 				s_exp.clone() * (r_x_affine_exp - affine_x),
 				s_exp.clone() * (r_y_affine_exp - affine_y),
 				s_exp * (r_z_exp * r_z_invert_exp - one),
@@ -590,20 +590,20 @@ impl<F: FieldExt> CommonChip<F> {
 
 				let x = region.assign_advice(
 					|| "r_x_affine",
-					config.eddsa_advice[0],
-					1,
+					config.eddsa_advice[3],
+					0,
 					|| r_x_affine.evaluate(),
 				)?;
 				let y = region.assign_advice(
 					|| "r_y_affine",
-					config.eddsa_advice[1],
-					1,
+					config.eddsa_advice[4],
+					0,
 					|| r_y_affine.evaluate(),
 				)?;
 				region.assign_advice(
 					|| "r_z_invert",
-					config.eddsa_advice[2],
-					1,
+					config.eddsa_advice[5],
+					0,
 					|| z_invert.evaluate(),
 				)?;
 

--- a/circuit/src/gadgets/common.rs
+++ b/circuit/src/gadgets/common.rs
@@ -15,14 +15,14 @@ pub struct CommonConfig {
 	selectors: [Selector; 6],
 }
 
-/// Structure for the chip.
+/// Structure for the common chip.
 pub struct CommonChip<F: FieldExt> {
 	/// Constructs a phantom data for the FieldExt.
 	_phantom: PhantomData<F>,
 }
 
 impl<F: FieldExt> CommonChip<F> {
-	/// Make the circuit config.
+	/// Make the circuit configs.
 	pub fn configure(meta: &mut ConstraintSystem<F>) -> CommonConfig {
 		let advice = [meta.advice_column(), meta.advice_column(), meta.advice_column()];
 		let selectors = [

--- a/circuit/src/gadgets/lt_eq.rs
+++ b/circuit/src/gadgets/lt_eq.rs
@@ -65,7 +65,7 @@ impl<F: FieldExt> LessEqualChip<F> {
 		let diff_b2n = Bits2NumChip::<_, DIFF_BITS>::configure(meta);
 		let x_b2n = Bits2NumChip::<_, NUM_BITS>::configure(meta);
 		let y_b2n = Bits2NumChip::<_, NUM_BITS>::configure(meta);
-		let is_zero = CommonChip::configure_gadgets(meta);
+		let is_zero = CommonChip::configure(meta);
 		let x = meta.advice_column();
 		let y = meta.advice_column();
 		let s = meta.selector();

--- a/circuit/src/gadgets/lt_eq.rs
+++ b/circuit/src/gadgets/lt_eq.rs
@@ -10,7 +10,7 @@ use halo2wrong::halo2::{
 
 use super::{
 	bits2num::{Bits2NumChip, Bits2NumConfig},
-	is_zero::{IsZeroChip, IsZeroConfig},
+	common::{CommonChip, CommonConfig},
 };
 
 /// 1 << 252
@@ -30,7 +30,7 @@ pub struct LessEqualConfig {
 	y_b2n: Bits2NumConfig,
 	diff_b2n: Bits2NumConfig,
 	/// Constructs is_zero circuit elements.
-	is_zero: IsZeroConfig,
+	is_zero: CommonConfig,
 	/// Configures a column for the x.
 	x: Column<Advice>,
 	/// Configures a column for the y.
@@ -65,7 +65,7 @@ impl<F: FieldExt> LessEqualChip<F> {
 		let diff_b2n = Bits2NumChip::<_, DIFF_BITS>::configure(meta);
 		let x_b2n = Bits2NumChip::<_, NUM_BITS>::configure(meta);
 		let y_b2n = Bits2NumChip::<_, NUM_BITS>::configure(meta);
-		let is_zero = IsZeroChip::configure(meta);
+		let is_zero = CommonChip::configure_gadgets(meta);
 		let x = meta.advice_column();
 		let y = meta.advice_column();
 		let s = meta.selector();
@@ -139,8 +139,11 @@ impl<F: FieldExt> LessEqualChip<F> {
 		// This means y is bigger than x and is_zero will return 1.
 		// If both are equal last bit still will be 1 and the number will be exactly 253
 		// bits. In that case, is_zero will return 0 as well.
-		let is_zero = IsZeroChip::new(bits[DIFF_BITS - 1].clone());
-		let res = is_zero.synthesize(config.is_zero, layouter.namespace(|| "is_zero"))?;
+		let res = CommonChip::is_zero(
+			bits[DIFF_BITS - 1].clone(),
+			config.is_zero,
+			layouter.namespace(|| "is_zero"),
+		)?;
 		Ok(res)
 	}
 }

--- a/circuit/src/gadgets/set.rs
+++ b/circuit/src/gadgets/set.rs
@@ -1,4 +1,4 @@
-use super::is_zero::{IsZeroChip, IsZeroConfig};
+use super::common::{CommonChip, CommonConfig};
 use halo2wrong::halo2::{
 	arithmetic::FieldExt,
 	circuit::{AssignedCell, Layouter, Region, Value},
@@ -10,7 +10,7 @@ use halo2wrong::halo2::{
 /// Configuration elements for the circuit defined here.
 pub struct FixedSetConfig {
 	/// Constructs is_zero circuit elements.
-	is_zero: IsZeroConfig,
+	is_zero: CommonConfig,
 	/// Configures a column for the target.
 	target: Column<Advice>,
 	/// Configures a fixed column for the items.
@@ -39,7 +39,7 @@ impl<F: FieldExt, const N: usize> FixedSetChip<F, N> {
 
 	/// Make the circuit config.
 	pub fn configure(meta: &mut ConstraintSystem<F>) -> FixedSetConfig {
-		let is_zero = IsZeroChip::configure(meta);
+		let is_zero = CommonChip::configure_gadgets(meta);
 		let target = meta.advice_column();
 		let items = meta.fixed_column();
 		let diffs = meta.advice_column();
@@ -72,8 +72,8 @@ impl<F: FieldExt, const N: usize> FixedSetChip<F, N> {
 				// That makes next_product_exp = 0
 				// => (1 * 0) - 0 == 0
 				s_exp.clone() * (product_exp * diff_exp.clone() - next_product_exp),
-				//TODO: uncomment this line when the bug is fixed.
-				//s_exp * (target_exp - (diff_exp + item_exp)),
+				// TODO: uncomment this line when the bug is fixed.
+				// s_exp * (target_exp - (diff_exp + item_exp)),
 			]
 		});
 
@@ -131,9 +131,8 @@ impl<F: FieldExt, const N: usize> FixedSetChip<F, N> {
 			},
 		)?;
 
-		let is_zero_chip = IsZeroChip::new(product);
 		let is_zero =
-			is_zero_chip.synthesize(config.is_zero, layouter.namespace(|| "is_member"))?;
+			CommonChip::is_zero(product, config.is_zero, layouter.namespace(|| "is_member"))?;
 
 		Ok(is_zero)
 	}

--- a/circuit/src/gadgets/set.rs
+++ b/circuit/src/gadgets/set.rs
@@ -39,7 +39,7 @@ impl<F: FieldExt, const N: usize> FixedSetChip<F, N> {
 
 	/// Make the circuit config.
 	pub fn configure(meta: &mut ConstraintSystem<F>) -> FixedSetConfig {
-		let is_zero = CommonChip::configure_gadgets(meta);
+		let is_zero = CommonChip::configure(meta);
 		let target = meta.advice_column();
 		let items = meta.fixed_column();
 		let diffs = meta.advice_column();

--- a/circuit/src/lib.rs
+++ b/circuit/src/lib.rs
@@ -141,7 +141,7 @@ impl<F: FieldExt, const S: usize, const B: usize, P: RoundParams<F, 5>> Circuit<
 	/// Make the circuit config.
 	fn configure(meta: &mut ConstraintSystem<F>) -> Self::Config {
 		let set = FixedSetChip::<_, B>::configure(meta);
-		let common = CommonChip::configure_gadgets(meta);
+		let common = CommonChip::configure(meta);
 		let poseidon = PoseidonChip::<_, 5, P>::configure(meta);
 		let sum = SumChip::<_, S>::configure(meta);
 

--- a/circuit/src/lib.rs
+++ b/circuit/src/lib.rs
@@ -25,11 +25,7 @@ pub mod rescue_prime;
 pub mod utils;
 
 use gadgets::{
-	and::{AndChip, AndConfig},
-	is_equal::{IsEqualChip, IsEqualConfig},
-	is_zero::{IsZeroChip, IsZeroConfig},
-	mul::{MulChip, MulConfig},
-	select::{SelectChip, SelectConfig},
+	common::{CommonChip, CommonConfig},
 	set::{FixedSetChip, FixedSetConfig},
 	sum::{SumChip, SumConfig},
 };
@@ -48,13 +44,9 @@ use std::marker::PhantomData;
 pub struct EigenTrustConfig {
 	// Gadgets
 	set: FixedSetConfig,
-	is_equal: IsEqualConfig,
-	and: AndConfig,
-	select: SelectConfig,
+	common: CommonConfig,
 	poseidon: PoseidonConfig<5>,
 	sum: SumConfig,
-	mul: MulConfig,
-	is_zero: IsZeroConfig,
 	// EigenTrust columns
 	temp: Column<Advice>,
 	pub_ins: Column<Instance>,
@@ -149,13 +141,9 @@ impl<F: FieldExt, const S: usize, const B: usize, P: RoundParams<F, 5>> Circuit<
 	/// Make the circuit config.
 	fn configure(meta: &mut ConstraintSystem<F>) -> Self::Config {
 		let set = FixedSetChip::<_, B>::configure(meta);
-		let is_equal = IsEqualChip::configure(meta);
-		let and = AndChip::configure(meta);
-		let select = SelectChip::configure(meta);
+		let common = CommonChip::configure_gadgets(meta);
 		let poseidon = PoseidonChip::<_, 5, P>::configure(meta);
 		let sum = SumChip::<_, S>::configure(meta);
-		let mul = MulChip::configure(meta);
-		let is_zero = IsZeroChip::configure(meta);
 
 		let temp = meta.advice_column();
 		let fixed = meta.fixed_column();
@@ -165,7 +153,7 @@ impl<F: FieldExt, const S: usize, const B: usize, P: RoundParams<F, 5>> Circuit<
 		meta.enable_constant(fixed);
 		meta.enable_equality(pub_ins);
 
-		EigenTrustConfig { set, is_equal, and, select, poseidon, sum, mul, is_zero, temp, pub_ins }
+		EigenTrustConfig { set, common, poseidon, sum, temp, pub_ins }
 	}
 
 	/// Synthesize the circuit.
@@ -240,19 +228,29 @@ impl<F: FieldExt, const S: usize, const B: usize, P: RoundParams<F, 5>> Circuit<
 		let is_bootstrap =
 			set_membership.synthesize(config.set, layouter.namespace(|| "set_membership"))?;
 		// Is the iteration equal to 0?
-		let is_eq_chip = IsEqualChip::new(iteration.clone(), zero);
-		let is_genesis = is_eq_chip.synthesize(config.is_equal, layouter.namespace(|| "is_eq"))?;
+		let is_genesis = CommonChip::is_equal(
+			iteration.clone(),
+			zero,
+			config.common,
+			layouter.namespace(|| "is_eq"),
+		)?;
 		// Is this the bootstrap peer at genesis epoch?
-		let and_chip = AndChip::new(is_bootstrap, is_genesis);
-		let is_bootstrap_and_genesis =
-			and_chip.synthesize(config.and, layouter.namespace(|| "and"))?;
+		let is_bootstrap_and_genesis = CommonChip::and(
+			is_bootstrap,
+			is_genesis,
+			config.common,
+			layouter.namespace(|| "and"),
+		)?;
 		// Select the appropriate score, depending on the conditions
-		let select_chip = SelectChip::new(is_bootstrap_and_genesis, bootstrap_score, t_i);
-		let t_i_select =
-			select_chip.synthesize(config.select.clone(), layouter.namespace(|| "select"))?;
+		let t_i_select = CommonChip::select(
+			is_bootstrap_and_genesis,
+			bootstrap_score,
+			t_i,
+			config.common,
+			layouter.namespace(|| "select"),
+		)?;
 
-		let mul_chip = MulChip::new(t_i_select, c_v);
-		let op_v = mul_chip.synthesize(config.mul, layouter.namespace(|| "mul"))?;
+		let op_v = CommonChip::mul(t_i_select, c_v, config.common, layouter.namespace(|| "mul"))?;
 
 		let m_hash_input = [epoch, iteration, op_v.clone(), pubkey_v, pubkey_i];
 		let poseidon_m_hash = PoseidonChip::<_, 5, P>::new(m_hash_input);
@@ -260,13 +258,19 @@ impl<F: FieldExt, const S: usize, const B: usize, P: RoundParams<F, 5>> Circuit<
 			.synthesize(config.poseidon, layouter.namespace(|| "poseidon_m_hash"))?;
 		let m_hash = res[0].clone();
 
-		let is_zero_chip = IsZeroChip::new(op_v);
-		let is_zero_opinion =
-			is_zero_chip.synthesize(config.is_zero, layouter.namespace(|| "is_zero_opinion"))?;
+		let is_zero_opinion = CommonChip::is_zero(
+			op_v,
+			config.common,
+			layouter.namespace(|| "is_zero_opinion"),
+		)?;
 
-		let m_hash_select = SelectChip::new(is_zero_opinion, out_m_hash, m_hash);
-		let final_m_hash =
-			m_hash_select.synthesize(config.select, layouter.namespace(|| "m_hash_select"))?;
+		let final_m_hash = CommonChip::select(
+			is_zero_opinion,
+			out_m_hash,
+			m_hash,
+			config.common,
+			layouter.namespace(|| "m_hash_select"),
+		)?;
 
 		layouter.constrain_instance(final_m_hash.cell(), config.pub_ins, 0)?;
 


### PR DESCRIPTION
Carried `eddsa` gadgets' configuration gates to the [common](https://github.com/eigen-trust/eigen-trust/blob/eddsa-common/circuit/src/gadgets/common.rs) and test cases to the [mod](https://github.com/eigen-trust/eigen-trust/blob/eddsa-common/circuit/src/eddsa/mod.rs). I implemented the common circuit to all of the other files so that we could delete files after the last task. Also, [here](https://github.com/eigen-trust/eigen-trust/blob/eddsa-common/circuit/src/gadgets/common.rs#L195) I did hard coding for the bits2num configuration since we always use 256 bits. 